### PR TITLE
Add V100 model sources and TE auto-promotion

### DIFF
--- a/MANIFEST.json
+++ b/MANIFEST.json
@@ -1,55 +1,63 @@
 {
   "package": "minimax-h3-v100-mixed-precision-patchers",
   "profile": "MiniMax H3 V100 mixed-precision patch: QKV and attention FP16; Q/K RMSNorm, RoPE, output projection, MLP and residual FP32",
-  "generated_date": "2026-08-05",
+  "generated_date": "2026-08-07",
   "files": {
     ".gitignore": {
       "bytes": 49,
       "sha256": "32a99b5d87c2e051b31a9deca3e7be4f8d42483b03a4146b402ef24bf2cab8d5"
     },
     "_patch_core.py": {
-      "bytes": 16787,
-      "sha256": "4305b3945fd494d9d34d4d903e09808f270e0c8281ed89724b287f87e5c1f9f1"
+      "bytes": 23486,
+      "sha256": "1d43ae7bb407c3c6fc50a3e3de2298b3043be89bcd7d477df6e272a7c6001e39"
     },
     "LICENSE": {
       "bytes": 35149,
       "sha256": "3972dc9744f6499f0f9b2dbf76696f2ae7ad8af9b23dde66d6af86c9dfb36986"
     },
     "NOTICE.md": {
-      "bytes": 1813,
-      "sha256": "a9f3bb10ded5f11dc7512552046fad84a674974b87f94a3c6e648194084866d1"
+      "bytes": 2484,
+      "sha256": "ea67bf7445e830591546f51ee5518e1d9f18ff677c3d1b0171da725881b0a52f"
     },
     "patch_h3_origin_v100.bat": {
-      "bytes": 902,
-      "sha256": "dd77d19710c5c7b57006465760a2c27b7a0bb3e8583066e512f05175fbd97e6e"
+      "bytes": 1323,
+      "sha256": "d808ba779622b20e2752895ce7e17ab56ca8d134ac0e6fe788f3abbc2111c8c3"
     },
     "patch_h3_origin_v100.py": {
       "bytes": 226,
       "sha256": "70d676dde67ae85154a9a2f7988d1f0f10c7e8ad4099061444b81ba42b7c4762"
     },
     "patch_te_v100.bat": {
-      "bytes": 895,
-      "sha256": "6b1dfec1d752b1dfe3bda34d891d334d1dcb1316578fac46a6ecfdb9f9b84a06"
+      "bytes": 1509,
+      "sha256": "7fa845c374c5ed832543f70a6bb1501035e56327bbc7a7dc821a30c43ab17382"
     },
     "patch_te_v100.py": {
-      "bytes": 222,
-      "sha256": "578c4c643f69ea0070c6655aa1080f7fd6ca3ce48e3556ddb5012ae47a54df4d"
+      "bytes": 247,
+      "sha256": "1cf4a0d4b4bad5c402bffd21b224c7d44b02aa1d3dc08c57ed9bb3c93797a784"
     },
     "README.md": {
-      "bytes": 5566,
-      "sha256": "fd33a147e52c5d4e3b012db25c9b449b49b95bd0ee46f1b127689426caf1bf3f"
+      "bytes": 7402,
+      "sha256": "511f93d594afdbfeed9f825af7fa098907e59edea5bfdc12b30cb6bc540cf0bc"
     },
     "README_zh-CN.md": {
-      "bytes": 5615,
-      "sha256": "549dd43b09d9a26999fdf7ccdfbc0a12971bc2ba83df17b44a7433d1656ab27a"
+      "bytes": 7428,
+      "sha256": "43ffb4216f3a3a0307b2e226cee0a37e54aa1f28f14081424232201b8836afa9"
     },
     "restore_h3_origin_v100.bat": {
-      "bytes": 198,
-      "sha256": "9b7595e2fdfcb0b1fd53eaac6dff61509af440c71fda51ecd5494128e3fa8b5d"
+      "bytes": 278,
+      "sha256": "3d77a96bc3122f0dddcf2ff53e8fa01d4be12a84df79f09fe17eaba3cb80d0a3"
     },
     "restore_te_v100.bat": {
-      "bytes": 191,
-      "sha256": "19dcb0f3c07352dd49dc7f9a2f2d8b15e412e2c87a879f09ec260c25782cd0dc"
+      "bytes": 1578,
+      "sha256": "97af485d1f62350e7b7bc71b60c028c91766a506d0cdad36ec389c4e1450b8a2"
+    },
+    "sources/origin_v100/model.py": {
+      "bytes": 34363,
+      "sha256": "ff86e416f7fb25d9cb68ceda6fb3e63f95e919db51c019a5a570171bbcd28b78"
+    },
+    "sources/te_v100/model.py": {
+      "bytes": 35612,
+      "sha256": "24c3a26708bd0d67f31013e483bd92cdf8d890ff10168c940e1e3532080e3f1c"
     }
   },
   "known_inputs": {
@@ -58,6 +66,7 @@
   },
   "known_outputs": {
     "origin_sha256": "ff86e416f7fb25d9cb68ceda6fb3e63f95e919db51c019a5a570171bbcd28b78",
-    "te_sha256": "53167a18ad0872d26a9e3502b9a6bc7c135bb10034c60f68e4ad9e93a93d55c6"
+    "te_sha256": "53167a18ad0872d26a9e3502b9a6bc7c135bb10034c60f68e4ad9e93a93d55c6",
+    "te_from_origin_sha256": "24c3a26708bd0d67f31013e483bd92cdf8d890ff10168c940e1e3532080e3f1c"
   }
 }

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -17,6 +17,13 @@
 
 The supplied origin and TE H3 files differ only by the TE-Speed `_run_blocks(start, end)` method and `("block_loop", 0)` forward hook. Their Attention implementation is identical before this V100 patch.
 
+## Bundled V100 source snapshots
+
+- `sources/origin_v100/model.py` contains the supported official/origin structure with the tested V100 Plan 2 precision patch applied.
+- `sources/te_v100/model.py` contains the verified TE-Speed hooks with the same V100 Plan 2 precision patch applied.
+
+The bundled files reproduce the installer-generated output hashes recorded in `MANIFEST.json`: `ff86e416...` for origin and `24c3a267...` for TE promoted from origin. Python AST parsing, variant detection and V100 patch-marker validation are run against both bundled files.
+
 ## Precision selection evidence
 
 The published patch is the V100-tested Plan 2 profile:
@@ -37,8 +44,8 @@ Validated on isolated copies of both supplied files:
 - Patch plus Python AST parse.
 - Patched origin and TE `Attention.forward` and `MiniMaxH3Model.__init__` ASTs are identical to the V100-tested Plan 2 file.
 - Repeated invocation produces no byte changes.
-- Each wrong-target patcher exits nonzero without modifying either file.
-- `--revert` restores the exact original SHA-256.
+- The origin patcher rejects TE input; the TE patcher safely promotes the verified origin input before applying the V100 patch.
+- `--revert` restores the exact pre-install SHA-256, including origin input promoted by the TE patcher.
 - Both patch BAT launchers, both dedicated restore BAT launchers and drag-and-drop positional path parsing were exercised.
 
 The development machine did not contain a V100, so the performance claim comes from the tester's V100 run rather than a local rerun.

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ English | [简体中文](README_zh-CN.md)
 
 Two version-gated installers for the tested MiniMax H3 V100 mixed-precision profile:
 
-- `patch_te_v100.bat` patches a `model.py` that already contains the TE-Speed `block_loop` hooks.
+- `patch_te_v100.bat` installs the TE-Speed version. On a supported clean origin file, it first installs the verified TE-Speed `block_loop` hooks and then applies the V100 patch.
 - `patch_h3_origin_v100.bat` patches the official/origin H3 `model.py` without those TE hooks.
 - `restore_te_v100.bat` restores the exact pre-patch TE backup.
 - `restore_h3_origin_v100.bat` restores the exact pre-patch origin backup.
 
-Do **not** run both patchers on the same file. Each patcher detects the target layout and refuses the wrong variant before writing anything.
+Do **not** run both patchers on the same file. The TE installer can promote a supported clean origin file to the TE layout; the origin installer still accepts only the official origin layout.
 
 ## Measured result
 
@@ -34,16 +34,27 @@ The 50 main DiT blocks use:
 
 The patch activates only when the incoming main-block tensor is CUDA FP32. BF16 and already-FP16 paths retain the source behavior.
 
+## Bundled source files
+
+Complete V100-accelerated `model.py` sources are included for developers who want to inspect, adapt or integrate the changes into their own ComfyUI builds:
+
+- [`sources/origin_v100/model.py`](sources/origin_v100/model.py): official/origin MiniMax H3 structure plus the tested V100 Plan 2 mixed-precision acceleration; no TE-Speed `block_loop` hook.
+- [`sources/te_v100/model.py`](sources/te_v100/model.py): TE-Speed `block_loop` hooks plus the same tested V100 Plan 2 acceleration.
+
+Both sources are derived from the ComfyUI MiniMax H3 implementation introduced by commit [`57500fc`](https://github.com/Comfy-Org/ComfyUI/commit/57500fc), whose clean origin `model.py` has SHA-256 `882c280b05aa60cd17f231e5e2389b921b52880fb3b4e23574c0aba5f2bd5024`.
+
+For a matching ComfyUI build, either file can be used as a drop-in `comfy/ldm/minimax/model.py` after making a backup. For newer, older or locally modified builds, use these files as reference sources and port the Attention precision changes and, when desired, the TE block-loop hooks into the local implementation instead of blindly overwriting it. Stop ComfyUI before replacing the file and validate the resulting Python syntax and model output before production use. These source copies are provided for manual development; the guarded BAT/Python installers remain the safer option for the supported build.
+
 ## One-click Windows usage
 
 1. Stop ComfyUI.
 2. Choose the BAT matching the active `model.py`:
-   - TE-Speed hooks already installed: `patch_te_v100.bat`
+   - TE-Speed version required (clean origin or already TE-hooked): `patch_te_v100.bat`
    - Official/origin H3 file: `patch_h3_origin_v100.bat`
-3. Drag `ComfyUI\comfy\ldm\minimax\model.py` onto the selected BAT file.
+3. Double-click the selected BAT. This customized build defaults to `C:\Users\Administrator\ComfyUI-Installs\ComfyUI\ComfyUI\comfy\ldm\minimax\model.py`; another `model.py` can still be dragged onto the BAT.
 4. Check that the console reports `Patched SHA-256`, then restart ComfyUI.
 
-To return to the pre-patch file, stop ComfyUI and drag the active `model.py` onto the matching restore BAT. The restore script validates the active variant, V100 patch markers and matching clean backup before it writes anything.
+To return to the pre-patch file, stop ComfyUI and run the matching restore BAT. If TE installation started from origin, `restore_te_v100.bat` restores that exact origin file; if it started from an existing TE file, it restores that exact TE file.
 
 The BAT launchers try, in order: `COMFYUI_PYTHON`, a nearby portable `python_embeded\python.exe`, the Windows `py -3` launcher, then `python` from `PATH`.
 
@@ -68,12 +79,12 @@ The scripts can also auto-locate common ComfyUI/portable layouts when launched f
 
 Before the first write, the installers make an exact adjacent backup:
 
-- TE variant: `model.py.v100_te.bak`
+- TE variant: `model.py.v100_te.bak` (the exact pre-install file, which may be origin or TE)
 - Origin variant: `model.py.v100_origin.bak`
 
 Safety behavior:
 
-- Exact TE/origin layout detection before patching.
+- Exact TE/origin layout detection before patching; origin-to-TE promotion runs only when both verified TE conversion anchors match.
 - Exact supported `Attention.forward` anchor required.
 - Refuses partial TE hooks, partial V100 patches and wrong-target patchers.
 - Refuses to overwrite a differing/stale backup.

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -4,12 +4,12 @@
 
 本项目提供两个带版本识别和安全检查的安装脚本，用于安装经过 V100 实测的 MiniMax H3 混合精度方案：
 
-- `patch_te_v100.bat`：用于已经包含 TE-Speed `block_loop` 钩子的 `model.py`。
+- `patch_te_v100.bat`：用于 TE-Speed 版本；如果目标是受支持的官方 origin 文件，会先自动安装经过校验的 TE-Speed `block_loop` 钩子，再应用 V100 补丁。
 - `patch_h3_origin_v100.bat`：用于不包含 TE 钩子的官方/原版 H3 `model.py`。
 - `restore_te_v100.bat`：恢复补丁前的 TE 版精确备份。
 - `restore_h3_origin_v100.bat`：恢复补丁前的官方/原版精确备份。
 
-不要对同一个文件同时运行两个补丁。每个补丁都会先识别目标文件结构；如果选错版本，会在写入前拒绝执行。
+不要对同一个文件同时运行两个补丁。TE 安装脚本可以自动把受支持的干净 origin 文件转换为 TE 版本；origin 安装脚本仍只接受官方原版结构。
 
 ## 实测结果
 
@@ -34,16 +34,27 @@ V100 测试用例：0.2 百万像素、5 秒、24 帧率。
 
 补丁只会在主 Block 的输入张量为 CUDA FP32 时启用。BF16 和已经使用 FP16 的路径保持源码原有行为。
 
+## 随附完整源码
+
+项目内提供两份完整的 V100 加速版 `model.py`，便于开发者检查代码、按需修改，或移植到自己的 ComfyUI 构建：
+
+- [`sources/origin_v100/model.py`](sources/origin_v100/model.py)：官方/origin MiniMax H3 结构，加上经过实测的 V100 Plan 2 混合精度加速；不包含 TE-Speed `block_loop` 钩子。
+- [`sources/te_v100/model.py`](sources/te_v100/model.py)：包含 TE-Speed `block_loop` 钩子，并使用相同的 V100 Plan 2 加速方案。
+
+两份源码均基于 ComfyUI 提交 [`57500fc`](https://github.com/Comfy-Org/ComfyUI/commit/57500fc) 中首次加入的 MiniMax H3 实现；对应干净 origin `model.py` 的 SHA-256 为 `882c280b05aa60cd17f231e5e2389b921b52880fb3b4e23574c0aba5f2bd5024`。
+
+如果 ComfyUI 构建与该源码版本匹配，可以先备份，再将所选文件作为 `comfy/ldm/minimax/model.py` 使用。对于更新、较旧或已自行修改的构建，应把这两份文件作为参考源码，将 Attention 精度改动以及可选的 TE Block Loop 钩子移植到本地实现，不建议直接覆盖。替换前请关闭 ComfyUI，并在正式使用前验证 Python 语法和模型输出。随附源码主要用于手动开发；对于受支持的版本，带安全检查的 BAT/Python 安装器仍是更稳妥的选择。
+
 ## Windows 一键使用
 
 1. 关闭 ComfyUI。
 2. 根据当前 `model.py` 选择对应 BAT：
-   - 已经安装 TE-Speed 钩子：`patch_te_v100.bat`
+   - 需要 TE-Speed 版本（当前文件可以是干净 origin 或已安装 TE 钩子）：`patch_te_v100.bat`
    - 官方/原版 H3 文件：`patch_h3_origin_v100.bat`
-3. 将 `ComfyUI\comfy\ldm\minimax\model.py` 拖到所选 BAT 文件上。
+3. 直接双击所选 BAT。本定制版默认目标为 `C:\Users\Administrator\ComfyUI-Installs\ComfyUI\ComfyUI\comfy\ldm\minimax\model.py`；也仍可将其他 `model.py` 拖到 BAT 上。
 4. 确认控制台显示 `Patched SHA-256`，然后重新启动 ComfyUI。
 
-如果要恢复补丁前的文件，请先关闭 ComfyUI，再将当前 `model.py` 拖到对应的恢复 BAT 上。恢复脚本会在写入前检查当前版本、V100 补丁标记以及匹配的干净备份。
+如果要恢复补丁前的文件，请先关闭 ComfyUI，再运行对应的恢复 BAT。若 TE 安装从 origin 文件开始，`restore_te_v100.bat` 会精确恢复该 origin 文件；若从已有 TE 文件开始，则精确恢复原 TE 文件。
 
 BAT 启动器会按以下顺序寻找 Python：`COMFYUI_PYTHON`、附近便携版的 `python_embeded\python.exe`、Windows `py -3` 启动器，以及 `PATH` 中的 `python`。
 
@@ -68,12 +79,12 @@ restore_h3_origin_v100.bat "D:\ComfyUI\comfy\ldm\minimax\model.py"
 
 首次写入前，安装脚本会在目标文件旁创建精确备份：
 
-- TE 版：`model.py.v100_te.bak`
+- TE 版：`model.py.v100_te.bak`（保存点击 TE 安装前的精确文件，可为 origin 或 TE）
 - 官方/原版：`model.py.v100_origin.bak`
 
 安全机制包括：
 
-- 写入前精确识别 TE/官方原版结构。
+- 写入前精确识别 TE/官方原版结构，并只在两个 TE 转换锚点均匹配时执行 origin→TE 转换。
 - 要求匹配受支持的 `Attention.forward` 锚点。
 - 拒绝处理不完整的 TE 钩子、不完整的 V100 补丁以及选错版本的补丁脚本。
 - 拒绝覆盖内容不同或已经过期的备份。

--- a/_patch_core.py
+++ b/_patch_core.py
@@ -51,6 +51,70 @@ PATCH_METHOD_MARKER = 'getattr(self, "fp16_qkv", False)'
 PATCH_FLAG_MARKER = "            block.attn.fp16_qkv = True"
 FINAL_LAYER_MARKER = "        self.final_layer = FinalLayer("
 
+TE_FORWARD_ANCHOR = '''    def forward(self, x, timestep, context, transformer_options={}, minimax_payload=None, **kwargs):
+'''
+
+TE_RUN_BLOCKS_METHOD = '''    def _run_blocks(self, h, t_emb, mod_segments, rope_freqs, transformer_options, start=0, end=None):
+        patches_replace = transformer_options.get("patches_replace", {})
+        blocks_replace = patches_replace.get("dit", {})
+        end = len(self.blocks) if end is None else end
+        prefetch_queue = comfy.model_prefetch.make_prefetch_queue(list(self.blocks[start:end]), h.device, transformer_options)
+        for i in range(start, end):
+            block = self.blocks[i]
+            comfy.model_prefetch.prefetch_queue_pop(prefetch_queue, h.device, block)
+            if ("double_block", i) in blocks_replace:
+                def block_wrap(args):
+                    return {"img": block(args["img"], args["t_emb"], args["mod_segments"], args["rope_freqs"],
+                                         transformer_options=args["transformer_options"])}
+                h = blocks_replace[("double_block", i)](
+                    {"img": h, "t_emb": t_emb, "mod_segments": mod_segments, "rope_freqs": rope_freqs,
+                     "transformer_options": transformer_options},
+                    {"original_block": block_wrap})["img"]
+            else:
+                h = block(h, t_emb, mod_segments, rope_freqs, transformer_options=transformer_options)
+        if prefetch_queue is not None:
+            comfy.model_prefetch.prefetch_queue_pop(prefetch_queue, h.device, None)
+        return h
+
+'''
+
+ORIGIN_BLOCK_LOOP = '''        # blocks
+        patches_replace = transformer_options.get("patches_replace", {})
+        blocks_replace = patches_replace.get("dit", {})
+        prefetch_queue = comfy.model_prefetch.make_prefetch_queue(list(self.blocks), device, transformer_options)
+        for i, block in enumerate(self.blocks):
+            comfy.model_prefetch.prefetch_queue_pop(prefetch_queue, device, block)
+            if ("double_block", i) in blocks_replace:
+                def block_wrap(args):
+                    return {"img": block(args["img"], args["t_emb"], args["mod_segments"], args["rope_freqs"],
+                                         transformer_options=args["transformer_options"])}
+                h = blocks_replace[("double_block", i)](
+                    {"img": h, "t_emb": t_emb, "mod_segments": mod_segments, "rope_freqs": rope_freqs,
+                     "transformer_options": transformer_options},
+                    {"original_block": block_wrap})["img"]
+            else:
+                h = block(h, t_emb, mod_segments, rope_freqs, transformer_options=transformer_options)
+        if prefetch_queue is not None:
+            comfy.model_prefetch.prefetch_queue_pop(prefetch_queue, device, None)
+'''
+
+TE_BLOCK_LOOP = '''        # blocks
+        # blocks (TE-Speed-MiniMaxH3-OSS hook)
+        patches_replace = transformer_options.get("patches_replace", {})
+        blocks_replace = patches_replace.get("dit", {})
+        cache_ranges = [(a, b) for a, b, kind in layout.segments if kind in ("audio", "video")]
+        if ("block_loop", 0) in blocks_replace:
+            def block_loop_wrap(args):
+                return {"img": self._run_blocks(args["img"], args["t_emb"], args["mod_segments"], args["rope_freqs"],
+                                                args["transformer_options"], args.get("start", 0), args.get("end"))}
+            h = blocks_replace[("block_loop", 0)](
+                {"img": h, "t_emb": t_emb, "mod_segments": mod_segments, "rope_freqs": rope_freqs,
+                 "transformer_options": transformer_options, "cache_ranges": cache_ranges, "block_count": len(self.blocks)},
+                {"original_block": block_loop_wrap})["img"]
+        else:
+            h = self._run_blocks(h, t_emb, mod_segments, rope_freqs, transformer_options)
+'''
+
 
 ORIGINAL_ATTENTION_METHOD = '''    def forward(self, x, rope_freqs=None, transformer_options={}):
         s = x.shape[0]
@@ -229,6 +293,25 @@ def apply_patch(text, expected_variant):
     return patched
 
 
+def install_te_hooks(text):
+    """Promote the supported clean origin layout to the TE-hooked layout."""
+    validate_target(text, "origin", allow_patched=False)
+    if text.count(TE_FORWARD_ANCHOR) != 1:
+        raise SystemExit("error: expected exactly one MiniMaxH3Model.forward anchor")
+    if text.count(ORIGIN_BLOCK_LOOP) != 1:
+        raise SystemExit(
+            "error: the origin block loop does not match the supported TE conversion; "
+            "no file was changed"
+        )
+
+    promoted = text.replace(TE_FORWARD_ANCHOR, TE_RUN_BLOCKS_METHOD + TE_FORWARD_ANCHOR, 1)
+    promoted = promoted.replace(ORIGIN_BLOCK_LOOP, TE_BLOCK_LOOP, 1)
+    ast.parse(promoted)
+    if detect_variant(promoted) != "te" or patch_state(promoted) != "unpatched":
+        raise SystemExit("error: internal origin-to-TE conversion validation failed")
+    return promoted
+
+
 def candidate_from_base(base):
     base = Path(base).expanduser()
     candidates = []
@@ -283,7 +366,7 @@ def unique_existing(candidates):
     return result
 
 
-def find_model_file(expected_variant, explicit=None):
+def find_model_file(expected_variant, explicit=None, allow_origin_to_te=False):
     if explicit:
         candidates = unique_existing(candidate_from_base(explicit))
         if not candidates:
@@ -294,13 +377,17 @@ def find_model_file(expected_variant, explicit=None):
             raw_candidates.extend(candidate_from_base(root))
         candidates = unique_existing(raw_candidates)
 
+    accepted_variants = {expected_variant}
+    if expected_variant == "te" and allow_origin_to_te:
+        accepted_variants.add("origin")
+
     matches = []
     wrong = []
     for candidate in candidates:
         try:
             _, text, _, _ = read_model(candidate)
             variant = detect_variant(text)
-            if variant == expected_variant:
+            if variant in accepted_variants:
                 matches.append(candidate)
             else:
                 wrong.append((candidate, variant))
@@ -317,7 +404,7 @@ def find_model_file(expected_variant, explicit=None):
     if wrong:
         listing = "\n  ".join("{0} ({1})".format(p, v) for p, v in wrong)
         raise SystemExit(
-            "error: found model.py files, but none is the requested {0} variant:\n  {1}"
+            "error: found model.py files, but none is a supported {0} target:\n  {1}"
             .format(expected_variant, listing)
         )
     raise SystemExit(
@@ -358,7 +445,7 @@ def print_status(target, variant, state, raw, text):
     print("Known source build: {0}".format(known_label))
 
 
-def run(expected_variant, argv=None):
+def run(expected_variant, argv=None, allow_origin_to_te=False):
     title = "TE-hooked H3" if expected_variant == "te" else "official H3 origin"
     parser = argparse.ArgumentParser(
         description="Patch {0} for the tested MiniMax H3 V100 Plan 2 precision split".format(title)
@@ -376,39 +463,69 @@ def run(expected_variant, argv=None):
     if len(explicit_values) > 1:
         raise SystemExit("error: use only one of path, --comfy-ui, or --model-file")
     explicit = explicit_values[0] if explicit_values else None
-    target = find_model_file(expected_variant, explicit)
+    target = find_model_file(expected_variant, explicit, allow_origin_to_te=allow_origin_to_te)
     backup = target.with_name(target.name + BACKUP_SUFFIX[expected_variant])
 
     raw, text, newline, has_bom = read_model(target)
-    state = validate_target(text, expected_variant)
-    print_status(target, expected_variant, state, raw, text)
+    active_variant = detect_variant(text)
+    promoting_origin = (
+        expected_variant == "te" and allow_origin_to_te and active_variant == "origin"
+    )
+    validation_variant = "origin" if promoting_origin else expected_variant
+    state = validate_target(text, validation_variant)
+    print_status(target, active_variant, state, raw, text)
+
+    if promoting_origin:
+        print("TE hook state:      origin detected; automatic TE promotion is available")
 
     if args.check:
         return 0
 
     if args.revert:
+        if promoting_origin:
+            if state == "unpatched":
+                print("Already restored to the clean origin file; no file was changed.")
+                return 0
+            raise SystemExit(
+                "error: the active origin file is not a TE patch; use restore_h3_origin_v100"
+            )
         if state != "patched":
             raise SystemExit("error: refusing to revert because the active file is not V100-patched")
         if not backup.is_file():
             raise SystemExit("error: no backup at {0}".format(backup))
         backup_raw, backup_text, _, _ = read_model(backup)
-        validate_target(backup_text, expected_variant, allow_patched=False)
+        backup_variant = detect_variant(backup_text)
+        if backup_variant not in ("origin", "te"):
+            raise SystemExit("error: backup is not a supported origin or TE model.py")
+        validate_target(backup_text, backup_variant, allow_patched=False)
         ast.parse(backup_text)
         atomic_replace(target, backup_raw)
         restored_raw, restored_text, _, _ = read_model(target)
-        validate_target(restored_text, expected_variant, allow_patched=False)
+        validate_target(restored_text, backup_variant, allow_patched=False)
         print("Restored SHA-256:   {0}".format(sha256_bytes(restored_raw)))
+        print("Restored variant:   {0}".format(backup_variant))
         print("Restored from:      {0}".format(backup))
         print("Restart ComfyUI before the next inference run.")
         return 0
 
     if state == "patched":
+        if promoting_origin:
+            raise SystemExit(
+                "error: origin V100 patch detected; restore it before installing the TE version"
+            )
         print("Already patched; no file was changed.")
         return 0
 
     if backup.is_file():
         backup_raw, backup_text, _, _ = read_model(backup)
-        validate_target(backup_text, expected_variant, allow_patched=False)
+        backup_variant = detect_variant(backup_text)
+        if backup_variant != active_variant:
+            raise SystemExit(
+                "error: existing backup is for {0}, but the active clean model is {1}. "
+                "Move the stale backup out of the way before patching: {2}"
+                .format(backup_variant, active_variant, backup)
+            )
+        validate_target(backup_text, backup_variant, allow_patched=False)
         if backup_raw != raw:
             raise SystemExit(
                 "error: existing backup differs from the active clean model. Move the stale backup "
@@ -419,7 +536,10 @@ def run(expected_variant, argv=None):
         shutil.copy2(str(target), str(backup))
         print("Backup written:     {0}".format(backup))
 
-    patched_text = apply_patch(text, expected_variant)
+    patch_source = install_te_hooks(text) if promoting_origin else text
+    if promoting_origin:
+        print("TE hooks installed:  origin -> te (in the verified output transaction)")
+    patched_text = apply_patch(patch_source, expected_variant)
     patched_raw = encode_model(patched_text, newline, has_bom)
     atomic_replace(target, patched_raw)
 
@@ -436,9 +556,9 @@ def run(expected_variant, argv=None):
     return 0
 
 
-def main(expected_variant):
+def main(expected_variant, allow_origin_to_te=False):
     try:
-        return run(expected_variant)
+        return run(expected_variant, allow_origin_to_te=allow_origin_to_te)
     except KeyboardInterrupt:
         print("error: interrupted; no further action taken", file=sys.stderr)
         return 130

--- a/patch_h3_origin_v100.bat
+++ b/patch_h3_origin_v100.bat
@@ -1,9 +1,19 @@
 @echo off
-setlocal
+setlocal EnableExtensions EnableDelayedExpansion
 cd /d "%~dp0"
 
 set "PATCH_SCRIPT=%~dp0patch_h3_origin_v100.py"
-call :run_python %*
+set "DEFAULT_MODEL_FILE=C:\Users\Administrator\ComfyUI-Installs\ComfyUI\ComfyUI\comfy\ldm\minimax\model.py"
+
+if "%~1"=="" (
+    call :run_python --model-file "%DEFAULT_MODEL_FILE%"
+) else if /i "%~1"=="--check" (
+    call :run_python --model-file "%DEFAULT_MODEL_FILE%" %*
+) else if /i "%~1"=="--revert" (
+    call :run_python --model-file "%DEFAULT_MODEL_FILE%" %*
+) else (
+    call :run_python %*
+)
 set "PATCH_RC=%ERRORLEVEL%"
 echo.
 if not "%V100_PATCH_NO_PAUSE%"=="1" pause
@@ -12,7 +22,7 @@ exit /b %PATCH_RC%
 :run_python
 if defined COMFYUI_PYTHON if exist "%COMFYUI_PYTHON%" (
     "%COMFYUI_PYTHON%" "%PATCH_SCRIPT%" %*
-    exit /b %ERRORLEVEL%
+    exit /b !ERRORLEVEL!
 )
 for %%P in (
     "%~dp0python_embeded\python.exe"
@@ -21,17 +31,17 @@ for %%P in (
     "%~dp0..\..\..\python_embeded\python.exe"
 ) do if exist "%%~fP" (
     "%%~fP" "%PATCH_SCRIPT%" %*
-    exit /b %ERRORLEVEL%
+    exit /b !ERRORLEVEL!
 )
 where py.exe >nul 2>nul
 if not errorlevel 1 (
     py -3 "%PATCH_SCRIPT%" %*
-    exit /b %ERRORLEVEL%
+    exit /b !ERRORLEVEL!
 )
 where python.exe >nul 2>nul
 if not errorlevel 1 (
     python "%PATCH_SCRIPT%" %*
-    exit /b %ERRORLEVEL%
+    exit /b !ERRORLEVEL!
 )
 echo ERROR: Python 3 was not found. Set COMFYUI_PYTHON to python.exe and retry.
 exit /b 9009

--- a/patch_te_v100.bat
+++ b/patch_te_v100.bat
@@ -1,9 +1,20 @@
 @echo off
-setlocal
+setlocal EnableExtensions EnableDelayedExpansion
 cd /d "%~dp0"
 
 set "PATCH_SCRIPT=%~dp0patch_te_v100.py"
-call :run_python %*
+set "DEFAULT_COMFYUI_INSTALL=C:\Users\Administrator\ComfyUI-Installs\ComfyUI"
+set "DEFAULT_MODEL_FILE=C:\Users\Administrator\ComfyUI-Installs\ComfyUI\ComfyUI\comfy\ldm\minimax\model.py"
+
+if "%~1"=="" (
+    call :run_python --model-file "%DEFAULT_MODEL_FILE%"
+) else if /i "%~1"=="--check" (
+    call :run_python --model-file "%DEFAULT_MODEL_FILE%" %*
+) else if /i "%~1"=="--revert" (
+    call :run_python --model-file "%DEFAULT_MODEL_FILE%" %*
+) else (
+    call :run_python %*
+)
 set "PATCH_RC=%ERRORLEVEL%"
 echo.
 if not "%V100_PATCH_NO_PAUSE%"=="1" pause
@@ -12,26 +23,28 @@ exit /b %PATCH_RC%
 :run_python
 if defined COMFYUI_PYTHON if exist "%COMFYUI_PYTHON%" (
     "%COMFYUI_PYTHON%" "%PATCH_SCRIPT%" %*
-    exit /b %ERRORLEVEL%
+    exit /b !ERRORLEVEL!
 )
 for %%P in (
+    "%DEFAULT_COMFYUI_INSTALL%\.venv\Scripts\python.exe"
+    "%DEFAULT_COMFYUI_INSTALL%\python_embeded\python.exe"
     "%~dp0python_embeded\python.exe"
     "%~dp0..\python_embeded\python.exe"
     "%~dp0..\..\python_embeded\python.exe"
     "%~dp0..\..\..\python_embeded\python.exe"
 ) do if exist "%%~fP" (
     "%%~fP" "%PATCH_SCRIPT%" %*
-    exit /b %ERRORLEVEL%
+    exit /b !ERRORLEVEL!
 )
 where py.exe >nul 2>nul
 if not errorlevel 1 (
     py -3 "%PATCH_SCRIPT%" %*
-    exit /b %ERRORLEVEL%
+    exit /b !ERRORLEVEL!
 )
 where python.exe >nul 2>nul
 if not errorlevel 1 (
     python "%PATCH_SCRIPT%" %*
-    exit /b %ERRORLEVEL%
+    exit /b !ERRORLEVEL!
 )
 echo ERROR: Python 3 was not found. Set COMFYUI_PYTHON to python.exe and retry.
 exit /b 9009

--- a/patch_te_v100.py
+++ b/patch_te_v100.py
@@ -7,4 +7,4 @@ from _patch_core import main
 
 
 if __name__ == "__main__":
-    raise SystemExit(main("te"))
+    raise SystemExit(main("te", allow_origin_to_te=True))

--- a/restore_h3_origin_v100.bat
+++ b/restore_h3_origin_v100.bat
@@ -2,7 +2,11 @@
 setlocal
 set "V100_PATCH_NO_PAUSE=1"
 
-call "%~dp0patch_h3_origin_v100.bat" --revert %*
+if "%~1"=="" (
+    call "%~dp0patch_h3_origin_v100.bat" --revert
+) else (
+    call "%~dp0patch_h3_origin_v100.bat" %* --revert
+)
 set "RESTORE_RC=%ERRORLEVEL%"
 echo.
 if not "%V100_RESTORE_NO_PAUSE%"=="1" pause

--- a/restore_te_v100.bat
+++ b/restore_te_v100.bat
@@ -1,9 +1,56 @@
 @echo off
-setlocal
-set "V100_PATCH_NO_PAUSE=1"
+setlocal EnableExtensions EnableDelayedExpansion
+cd /d "%~dp0"
 
-call "%~dp0patch_te_v100.bat" --revert %*
+set "PATCH_SCRIPT=%~dp0patch_te_v100.py"
+set "DEFAULT_COMFYUI_INSTALL=C:\Users\Administrator\ComfyUI-Installs\ComfyUI"
+set "DEFAULT_MODEL_FILE=C:\Users\Administrator\ComfyUI-Installs\ComfyUI\ComfyUI\comfy\ldm\minimax\model.py"
+
+if not exist "%PATCH_SCRIPT%" (
+    echo ERROR: Required file not found: "%PATCH_SCRIPT%"
+    echo Extract the complete patcher folder before running this BAT file.
+    set "RESTORE_RC=2"
+    goto :finish
+)
+
+if "%~1"=="" (
+    call :run_python --model-file "%DEFAULT_MODEL_FILE%" --revert
+) else (
+    call :run_python %* --revert
+)
 set "RESTORE_RC=%ERRORLEVEL%"
+goto :finish
+
+:run_python
+if defined COMFYUI_PYTHON if exist "%COMFYUI_PYTHON%" (
+    "%COMFYUI_PYTHON%" "%PATCH_SCRIPT%" %*
+    exit /b !ERRORLEVEL!
+)
+for %%P in (
+    "%DEFAULT_COMFYUI_INSTALL%\.venv\Scripts\python.exe"
+    "%DEFAULT_COMFYUI_INSTALL%\python_embeded\python.exe"
+    "%~dp0python_embeded\python.exe"
+    "%~dp0..\python_embeded\python.exe"
+    "%~dp0..\..\python_embeded\python.exe"
+    "%~dp0..\..\..\python_embeded\python.exe"
+) do if exist "%%~fP" (
+    "%%~fP" "%PATCH_SCRIPT%" %*
+    exit /b !ERRORLEVEL!
+)
+where py.exe >nul 2>nul
+if not errorlevel 1 (
+    py -3 "%PATCH_SCRIPT%" %*
+    exit /b !ERRORLEVEL!
+)
+where python.exe >nul 2>nul
+if not errorlevel 1 (
+    python "%PATCH_SCRIPT%" %*
+    exit /b !ERRORLEVEL!
+)
+echo ERROR: Python 3 was not found. Set COMFYUI_PYTHON to python.exe and retry.
+exit /b 9009
+
+:finish
 echo.
 if not "%V100_RESTORE_NO_PAUSE%"=="1" pause
 exit /b %RESTORE_RC%

--- a/sources/origin_v100/model.py
+++ b/sources/origin_v100/model.py
@@ -1,0 +1,674 @@
+"""MiniMax H3 audio-video DiT.
+
+Single-stream packed-token transformer denoising video (24ch, patch 1x2x2) and
+stereo audio (32ch, 40 Hz) latents jointly, conditioned on Qwen3-VL layer-50 hidden states.
+The packed sequence is:
+[text | cond rows | audio | video] for t2va/fl2va
+[text | reference blocks | audio | video] for ref2va
+
+Timestep domain: the model receives the *video* sigma from the sampler and
+derives per-token timesteps t = 1 - sigma internally; the audio stream runs on
+its own shifted schedule (sigma_shift video 12.0 / audio 3.0), mapped from the
+video sigma in closed form. The audio velocity is returned scaled by the
+schedule map's derivative d(sigma_a)/d(sigma_v).
+"""
+
+import math
+
+import torch
+import torch.nn as nn
+
+import comfy.ldm.common_dit
+import comfy.model_management
+import comfy.model_prefetch
+import comfy.ops
+import comfy.patcher_extension
+import comfy.quant_ops
+from comfy.ldm.modules.attention import optimized_attention
+
+FRAME_PER_TOKEN = (1, 4, 4, 4, 4)
+FRAME_RESCALE = 5.0 / 3.0
+VISUAL_COND_TIMESTEP = 0.999
+AUDIO_COND_TIMESTEP = 1.0
+
+
+def time_shift_sigma(sigma, from_shift, to_shift):
+    # invert sigma = s*b/(1+(s-1)*b) to the base grid, re-apply the other shift
+    base = sigma / (from_shift + sigma * (1.0 - from_shift))
+    return to_shift * base / (1.0 + (to_shift - 1.0) * base)
+
+
+def time_shift_slope(sigma, from_shift, to_shift):
+    """d(sigma_to)/d(sigma_from) at the same base-grid point.
+
+    Scaling a stream's returned velocity by this slope makes the flat ODE that
+    any sampler integrates on the from-schedule equal to that stream's true ODE
+    on its own schedule.
+    """
+    base = sigma / (from_shift + sigma * (1.0 - from_shift))
+    return (to_shift * (1.0 + (from_shift - 1.0) * base) ** 2) / (from_shift * (1.0 + (to_shift - 1.0) * base) ** 2)
+
+
+def patchify_video(latent, patch_size=(1, 2, 2)):
+    # [B, C, T, H, W] -> [B*t*h*w, C*pt*ph*pw]
+    b, c, t_full, h_full, w_full = latent.shape
+    pt, ph, pw = patch_size
+    t, h, w = t_full // pt, h_full // ph, w_full // pw
+    x = latent.reshape(b, c, t, pt, h, ph, w, pw)
+    x = torch.einsum("nctrhpwq->nthwcrpq", x)
+    return x.reshape(b * t * h * w, c * pt * ph * pw)
+
+
+def unpatchify_video(rows, t, h, w, c=24, patch_size=(1, 2, 2)):
+    pt, ph, pw = patch_size
+    x = rows.reshape(-1, t, h, w, c, pt, ph, pw)
+    x = torch.einsum("nthwcrpq->nctrhpwq", x)
+    return x.reshape(-1, c, t * pt, h * ph, w * pw)
+
+
+def pack_audio(latent):
+    # [B, C=32, ch=2, T] -> [ch*T, 32] channel-major (ch0 t0..T-1, ch1 t0..T-1)
+    b, c, ch, t = latent.shape
+    return latent[0].permute(1, 2, 0).reshape(ch * t, c)
+
+
+def unpack_audio(rows, ch=2):
+    t = rows.shape[0] // ch
+    return rows.reshape(ch, t, rows.shape[-1]).permute(2, 0, 1).unsqueeze(0)
+
+
+def _axis_from_sqrt_area(dim, patch, sqrt_area):
+    # linspace((1 - ratio) / 2, (1 + ratio) / 2, dim // patch, endpoint=False) * 32
+    ratio = dim / sqrt_area
+    n = dim // patch
+    return (torch.arange(n, dtype=torch.float64) * (ratio / n) + (1.0 - ratio) / 2.0) * 32.0
+
+
+def _frame_grid(h, w):
+    # area-normalized (h, w) coordinates of one latent frame's 2x2-patch rows
+    area = math.sqrt(h * w)
+    hh, ww = torch.meshgrid(_axis_from_sqrt_area(h, 2, area), _axis_from_sqrt_area(w, 2, area), indexing="ij")
+    return torch.stack([hh.reshape(-1), ww.reshape(-1)], dim=-1), _axis_from_sqrt_area(w, 2, area)
+
+
+def _video_t_spans(n):
+    return [FRAME_RESCALE * FRAME_PER_TOKEN[k % 5] for k in range(n)]
+
+
+def _video_t_grid(n, origin):
+    # origin + exclusive cumsum
+    spans = torch.tensor(_video_t_spans(n), dtype=torch.float64)
+    return float(origin) + torch.cat([torch.zeros(1, dtype=torch.float64), spans[:-1].cumsum(0)])
+
+
+def _audio_grid(cursor, t, w_low, w_high):
+    # channel-major stereo rows: t advances per latent frame, w pinned to the grid extremes per stereo channel, h stays 0
+    g = torch.zeros(t * 2, 3, dtype=torch.float64)
+    g[:, 0] = (cursor + torch.arange(t, dtype=torch.float64)).repeat(2)
+    g[:t, 2] = w_low
+    g[t:, 2] = w_high
+    return g
+
+
+def _video_grid(vt, frame, cursor):
+    g = torch.empty(vt, frame.shape[0], 3, dtype=torch.float64)
+    g[:, :, 0] = _video_t_grid(vt, cursor)[:, None]
+    g[:, :, 1:] = frame[None]
+    return g.reshape(-1, 3)
+
+
+class TimeEmbedder(nn.Module):
+    def __init__(self, freq_dim, hidden, out, dtype=None, device=None, operations=None):
+        super().__init__()
+        self.freq_dim = freq_dim
+        self.proj_in = operations.Linear(freq_dim, hidden, bias=True, dtype=dtype, device=device)
+        self.proj_out = operations.Linear(hidden, out, bias=True, dtype=dtype, device=device)
+
+    def forward(self, t):
+        # t: [M] in [0, 1]; fp32 throughout, cos before sin
+        half = self.freq_dim // 2
+        freqs = torch.exp(-math.log(10000.0) * torch.arange(half, dtype=torch.float32, device=t.device) / half)
+        args = t.to(torch.float32)[:, None] * freqs[None]
+        emb = torch.cat([torch.cos(args), torch.sin(args)], dim=-1)
+        return self.proj_out(nn.functional.silu(self.proj_in(emb)))
+
+
+def rope_rotation_table(angles, dtype):
+    """[S, rot_dim] pair angles -> [1, S, 1, rot_dim/2, 2, 2] rotation matrices."""
+    half = angles.shape[-1] // 2
+    ang = angles[:, :half]  # duplicated halves: [:, :half] == [:, half:]
+    c, s = torch.cos(ang), torch.sin(ang)
+    table = torch.stack([c, -s, s, c], dim=-1).reshape(1, angles.shape[0], 1, half, 2, 2)
+    return table.to(dtype)
+
+
+class Attention(nn.Module):
+    def __init__(self, hidden, heads, head_dim, eps, dtype=None, device=None, operations=None):
+        super().__init__()
+        self.heads = heads
+        self.head_dim = head_dim
+        inner = heads * head_dim
+        self.qkv_proj = operations.Linear(hidden, inner * 3, bias=False, dtype=dtype, device=device)
+        self.q_norm = operations.RMSNorm(head_dim, eps=eps, dtype=dtype, device=device)
+        self.k_norm = operations.RMSNorm(head_dim, eps=eps, dtype=dtype, device=device)
+        self.out_proj = operations.Linear(inner, hidden, bias=False, dtype=dtype, device=device)
+
+    def forward(self, x, rope_freqs=None, transformer_options={}):
+        s = x.shape[0]
+        residual_dtype = x.dtype
+        use_fp16 = (
+            getattr(self, "fp16_qkv", False)
+            and x.device.type == "cuda"
+            and x.dtype == torch.float32
+        )
+
+        # MiniMax H3 V100 acceleration (tested Plan 2): QKV projection and
+        # attention use FP16 Tensor Cores. Q/K return to FP32 immediately for
+        # RMSNorm and RoPE. Output projection, MLP, AdaLN and residual stay FP32.
+        proj_x = x.half() if use_fp16 else x
+        q, k, v = self.qkv_proj(proj_x).split(self.heads * self.head_dim, dim=-1)
+        if use_fp16:
+            q = q.float()
+            k = k.float()
+        v = v.view(s, self.heads, self.head_dim)
+        if rope_freqs is not None:
+            q = q.view(1, s, self.heads, self.head_dim)
+            k = k.view(1, s, self.heads, self.head_dim)
+            qw = comfy.model_management.cast_to(self.q_norm.weight, dtype=q.dtype, device=x.device)
+            kw = comfy.model_management.cast_to(self.k_norm.weight, dtype=k.dtype, device=x.device)
+            rope = rope_freqs.to(q.dtype) if rope_freqs.dtype != q.dtype else rope_freqs
+            rot = rope.shape[-3] * 2
+            if comfy.model_management.in_training:
+                q, k = comfy.quant_ops.ck.rms_rope_split_half(
+                    q, k, rope, qw, kw, epsilon=self.q_norm.eps, rot_dim=rot)
+            else:
+                comfy.quant_ops.ck.rms_rope_split_half_(
+                    q, k, rope, qw, kw, epsilon=self.q_norm.eps, rot_dim=rot)
+            q = q[0]
+            k = k[0]
+        else:
+            q = self.q_norm(q.view(s, self.heads, self.head_dim))
+            k = self.k_norm(k.view(s, self.heads, self.head_dim))
+        q = q.transpose(0, 1).unsqueeze(0)
+        k = k.transpose(0, 1).unsqueeze(0)
+        v = v.transpose(0, 1).unsqueeze(0)
+
+        if use_fp16:
+            out = optimized_attention(
+                q.half(), k.half(), v.half(), self.heads, mask=None,
+                skip_reshape=True, transformer_options=transformer_options,
+            ).to(residual_dtype)
+        else:
+            out = optimized_attention(
+                q, k, v, self.heads, mask=None, skip_reshape=True,
+                transformer_options=transformer_options,
+            )
+        return self.out_proj(out.squeeze(0))
+
+
+class MLP(nn.Module):
+    def __init__(self, hidden, ffn, dtype=None, device=None, operations=None):
+        super().__init__()
+        self.fc1 = operations.Linear(hidden, ffn * 2, bias=False, dtype=dtype, device=device)
+        self.fc2 = operations.Linear(ffn, hidden, bias=False, dtype=dtype, device=device)
+
+    def forward(self, x):
+        return comfy.ops.linear_input_act(self.fc2, self.fc1(x), "swiglu")
+
+
+class AdalnProj(nn.Module):
+    def __init__(self, t_dim, hidden, expand, modalities, apply_silu=True,
+                 dtype=None, device=None, operations=None):
+        super().__init__()
+        self.expand = expand
+        self.modalities = modalities
+        self.hidden = hidden
+        self.apply_silu = apply_silu
+        self.linear = operations.Linear(t_dim, expand * hidden * modalities, bias=True, dtype=dtype, device=device)
+
+    def forward(self, t_emb):
+        # [M, t_dim] -> expand tensors of [M*modalities, hidden]
+        x = self.linear(nn.functional.silu(t_emb) if self.apply_silu else t_emb)
+        x = x.view(x.shape[0] * self.modalities, self.expand * self.hidden)
+        return x.chunk(self.expand, dim=-1)
+
+
+def _mod_scale_shift(h, shift, scale, segments):
+    # segments: [(start, stop, mod_row)] covering h contiguously.
+    for a, b, row in segments:
+        h[a:b].mul_(1.0 + scale[row].to(h.dtype)).add_(shift[row].to(h.dtype))
+    return h
+
+
+def _mod_gate(x, gate, other, segments):
+    # other is the fresh attn/mlp output: accumulate the gated residual into the stream in place, one fused kernel per segment
+    for a, b, row in segments:
+        x[a:b].addcmul_(other[a:b], gate[row].to(x.dtype))
+    return x
+
+
+class RefinerBlock(nn.Module):
+    def __init__(self, hidden, heads, head_dim, ffn, eps, qk_eps, dtype=None, device=None, operations=None):
+        super().__init__()
+        self.norm1 = operations.RMSNorm(hidden, eps=eps, dtype=dtype, device=device)
+        self.norm2 = operations.RMSNorm(hidden, eps=eps, dtype=dtype, device=device)
+        self.attn = Attention(hidden, heads, head_dim, qk_eps, dtype=dtype, device=device, operations=operations)
+        self.mlp = MLP(hidden, ffn, dtype=dtype, device=device, operations=operations)
+
+    def forward(self, x, transformer_options={}):
+        # attn/mlp outputs are fresh: accumulate residuals in place
+        x = self.attn(self.norm1(x), transformer_options=transformer_options).add_(x)
+        return self.mlp(self.norm2(x)).add_(x)
+
+
+class TokenRefiner(nn.Module):
+    def __init__(self, num_layers, hidden, heads, head_dim, ffn, eps, qk_eps, final_eps,
+                 dtype=None, device=None, operations=None):
+        super().__init__()
+        self.blocks = nn.ModuleList([
+            RefinerBlock(hidden, heads, head_dim, ffn, eps, qk_eps, dtype=dtype, device=device, operations=operations)
+            for _ in range(num_layers)])
+        self.final_norm = operations.RMSNorm(hidden, eps=final_eps, dtype=dtype, device=device)
+
+    def forward(self, x, transformer_options={}):
+        for block in self.blocks:
+            x = block(x, transformer_options=transformer_options)
+        return self.final_norm(x)
+
+
+class DiTBlock(nn.Module):
+    def __init__(self, hidden, heads, head_dim, ffn, t_dim, eps, qk_eps,
+                 apply_silu=True, adaln_dtype=None, dtype=None, device=None, operations=None):
+        super().__init__()
+        self.norm1 = operations.RMSNorm(hidden, eps=eps, dtype=dtype, device=device)
+        self.norm2 = operations.RMSNorm(hidden, eps=eps, dtype=dtype, device=device)
+        self.attn = Attention(hidden, heads, head_dim, qk_eps, dtype=dtype, device=device, operations=operations)
+        self.mlp = MLP(hidden, ffn, dtype=dtype, device=device, operations=operations)
+        self.adaln_proj = AdalnProj(t_dim, hidden, 6, 3, apply_silu=apply_silu,
+                                    dtype=adaln_dtype if adaln_dtype is not None else dtype,
+                                    device=device, operations=operations)
+
+    def forward(self, x, t_emb, mod_segments, rope_freqs, transformer_options={}):
+        shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = self.adaln_proj(t_emb)
+        h = _mod_scale_shift(self.norm1(x), shift_msa, scale_msa, mod_segments)
+        x = _mod_gate(x, gate_msa, self.attn(h, rope_freqs=rope_freqs, transformer_options=transformer_options), mod_segments)
+        h = _mod_scale_shift(self.norm2(x), shift_mlp, scale_mlp, mod_segments)
+        return _mod_gate(x, gate_mlp, self.mlp(h), mod_segments)
+
+
+class FinalLayer(nn.Module):
+    def __init__(self, hidden, t_dim, video_dim, audio_dim, eps, apply_silu=True, adaln_dtype=None,
+                 dtype=None, device=None, operations=None):
+        super().__init__()
+        self.norm = operations.RMSNorm(hidden, eps=eps, dtype=dtype, device=device)
+        self.adaln_proj = AdalnProj(t_dim, hidden, 2, 1, apply_silu=apply_silu,
+                                    dtype=adaln_dtype if adaln_dtype is not None else dtype,
+                                    device=device, operations=operations)
+        # output heads are the checkpoint's fp32 island; norm/adaln are stored at model dtype
+        self.video_out = operations.Linear(hidden, video_dim, bias=True, dtype=torch.float32, device=device)
+        self.audio_out = operations.Linear(hidden, audio_dim, bias=True, dtype=torch.float32, device=device)
+
+    def forward(self, x, t_emb, video_seg, audio_seg):
+        # video_seg / audio_seg: (start, stop, timestep_row) of the target streams
+        shift, scale = self.adaln_proj(t_emb)
+        va, vb, vrow = video_seg
+        aa, ab, arow = audio_seg
+        hv = (self.norm(x[va:vb]) * (1.0 + scale[vrow]) + shift[vrow]).to(torch.float32)
+        ha = (self.norm(x[aa:ab]) * (1.0 + scale[arow]) + shift[arow]).to(torch.float32)
+        return self.video_out(hv), self.audio_out(ha)
+
+
+class PackedLayout:
+    """Static packed-sequence structure for one shape/conditioning signature."""
+
+    def __init__(self, text_len, latent_t, latent_h, latent_w, audio_t, keyframes=None, refs=None, frame_count=None):
+        frame, w_grid = _frame_grid(latent_h, latent_w)
+        frame_rows = frame.shape[0]
+
+        segments = [("text", text_len)]  # (kind, n_rows)
+        g = torch.zeros(text_len, 3, dtype=torch.float64)
+        g[:, 0] = torch.arange(text_len, dtype=torch.float64)
+        pos = [g]  # per segment: [n, 3] float64 (t, h, w)
+
+        img_pos, img_update = [], []
+        audio_pos, audio_update = [], []
+        cursor = text_len
+        row = text_len
+
+        if keyframes:
+            # fl2va: keyframe cond rows right after text, sharing the target spatial grid
+            for kf in keyframes:
+                pixel_index = kf["resolved_frame_index"]
+                if pixel_index == 0:
+                    cond_t = float(text_len)
+                elif frame_count is not None and pixel_index == frame_count - 1:
+                    cond_t = float(text_len) + sum(_video_t_spans(latent_t)) - FRAME_RESCALE
+                else:
+                    raise ValueError("only first/last keyframe anchors are supported")
+                g = torch.empty(frame_rows, 3, dtype=torch.float64)
+                g[:, 0] = cond_t
+                g[:, 1:] = frame
+                segments.append(("cond", frame_rows))
+                pos.append(g)
+                img_pos.append(torch.arange(row, row + frame_rows))
+                img_update.append(torch.zeros(frame_rows, dtype=torch.bool))
+                row += frame_rows
+
+        target_audio_w = (float(w_grid[0]), float(w_grid[-1]))
+        if refs:
+            cursor = float(text_len)
+            for blk in refs:
+                kind = blk["kind"]
+                if kind == "image":
+                    r_frame, _ = _frame_grid(blk["latent_h"], blk["latent_w"])
+                    n = r_frame.shape[0]
+                    g = torch.empty(n, 3, dtype=torch.float64)
+                    g[:, 0] = cursor
+                    g[:, 1:] = r_frame
+                    segments.append(("ref_img", n))
+                    pos.append(g)
+                    img_pos.append(torch.arange(row, row + n))
+                    img_update.append(torch.zeros(n, dtype=torch.bool))
+                    row += n
+                    cursor += 1.0
+                elif kind == "audio":
+                    rt = blk["ref_audio_t"]
+                    if rt > 0:
+                        segments.append(("ref_audio", rt * 2))
+                        pos.append(_audio_grid(cursor, rt, *target_audio_w))
+                        audio_pos.append(torch.arange(row, row + rt * 2))
+                        audio_update.append(torch.zeros(rt * 2, dtype=torch.bool))
+                        row += rt * 2
+                    cursor += float(rt)
+                elif kind in ("video", "video_audio"):
+                    # the block's audio rows pack immediately before its video
+                    # rows, both sharing the cursor origin
+                    rt = blk["ref_audio_t"]
+                    vt = blk["latent_t"]
+                    r_frame, r_w_grid = _frame_grid(blk["latent_h"], blk["latent_w"])
+                    if rt > 0:
+                        segments.append(("ref_audio", rt * 2))
+                        pos.append(_audio_grid(cursor, rt, float(r_w_grid[0]), float(r_w_grid[-1])))
+                        audio_pos.append(torch.arange(row, row + rt * 2))
+                        audio_update.append(torch.zeros(rt * 2, dtype=torch.bool))
+                        row += rt * 2
+                    n = vt * r_frame.shape[0]
+                    segments.append(("ref_img", n))
+                    pos.append(_video_grid(vt, r_frame, cursor))
+                    img_pos.append(torch.arange(row, row + n))
+                    img_update.append(torch.zeros(n, dtype=torch.bool))
+                    row += n
+                    cursor += max(float(rt), sum(_video_t_spans(vt)))
+
+        # target audio then target video, always the last two segments
+        segments.append(("audio", audio_t * 2))
+        pos.append(_audio_grid(cursor, audio_t, *target_audio_w))
+        audio_pos.append(torch.arange(row, row + audio_t * 2))
+        audio_update.append(torch.ones(audio_t * 2, dtype=torch.bool))
+        row += audio_t * 2
+
+        n_video = latent_t * frame_rows
+        segments.append(("video", n_video))
+        pos.append(_video_grid(latent_t, frame, cursor))
+        img_pos.append(torch.arange(row, row + n_video))
+        img_update.append(torch.ones(n_video, dtype=torch.bool))
+        row += n_video
+
+        self.seq_len = row
+        self.position_ids = torch.cat(pos)  # [S, 3] float64
+        self.img_pos = torch.cat(img_pos)
+        self.img_update = torch.cat(img_update)
+        self.audio_pos = torch.cat(audio_pos)
+        self.audio_update = torch.cat(audio_update)
+        self.signature = (text_len, latent_t, latent_h, latent_w, audio_t)
+        # contiguous segment table (start, stop, kind)
+        # kinds: text / cond / ref_img / ref_audio / audio / video
+        # the packed sequence is uniform per segment in (modality tag, timestep class),
+        # except the text span (tag runs resolved at forward time from the presentation tags)
+        seg_abs = []
+        off = 0
+        for kind, n in segments:
+            seg_abs.append((off, off + n, kind))
+            off += n
+        self.segments = seg_abs
+
+
+class MiniMaxH3Model(nn.Module):
+    def __init__(self, hidden_size=5376, num_layers=50, token_refiner_num_layers=2,
+                 num_attention_heads=56, attention_head_dim=128, ffn_hidden_size=14336,
+                 latents_dim=24, audio_latents_dim=32, patch_size=(1, 2, 2), text_dim=5120,
+                 timestep_input_dim=256, time_embed_hidden_size=5376, time_embed_dim=2688,
+                 rope_inv_freq_len=16, norm_eps=1e-5, qk_norm_eps=1e-5, final_norm_eps=1e-5,
+                 sigma_shift_video=12.0, sigma_shift_audio=3.0,
+                 adaln_curve_grid=None,
+                 image_model=None, dtype=None, device=None, operations=None, **kwargs):
+        super().__init__()
+        self.dtype = dtype
+        self.hidden_size = hidden_size
+        self.patch_size = tuple(patch_size)
+        self.latents_dim = latents_dim
+        self.audio_latents_dim = audio_latents_dim
+        self.sigma_shift_video = sigma_shift_video
+        self.sigma_shift_audio = sigma_shift_audio
+        self.use_adaln_curves = adaln_curve_grid is not None
+        # curve-form checkpoints replace the time embedder and full-width adaln weights with a small shared basis of the time-embedding curve
+        curve = {"apply_silu": not self.use_adaln_curves,
+                 "adaln_dtype": torch.float32 if self.use_adaln_curves else dtype}
+        video_patch_dim = latents_dim * self.patch_size[0] * self.patch_size[1] * self.patch_size[2]
+
+        self.video_patch_proj = operations.Linear(video_patch_dim, hidden_size, bias=True, dtype=torch.float32, device=device)
+        self.audio_patch_proj = operations.Linear(audio_latents_dim, hidden_size, bias=True, dtype=torch.float32, device=device)
+        self.condition_proj = operations.Linear(text_dim, hidden_size, bias=True, dtype=dtype, device=device)
+        if self.use_adaln_curves:
+            self.register_buffer("adaln_t_table", torch.empty(adaln_curve_grid, time_embed_dim, dtype=torch.float32))
+        else:
+            self.time_embedder = TimeEmbedder(timestep_input_dim, time_embed_hidden_size, time_embed_dim,
+                                              dtype=torch.float32, device=device, operations=operations)
+        self.rope = nn.Module()
+        self.rope.register_buffer("inv_freq", torch.empty(rope_inv_freq_len, dtype=torch.float32))
+        self.token_refiner = TokenRefiner(token_refiner_num_layers, hidden_size, num_attention_heads,
+                                          attention_head_dim, ffn_hidden_size, norm_eps, qk_norm_eps,
+                                          final_norm_eps, dtype=dtype, device=device, operations=operations)
+        self.blocks = nn.ModuleList([
+            DiTBlock(hidden_size, num_attention_heads, attention_head_dim, ffn_hidden_size,
+                     time_embed_dim, norm_eps, qk_norm_eps, **curve, dtype=dtype, device=device, operations=operations)
+            for _ in range(num_layers)])
+        # MiniMax H3 V100 Plan 2: enable FP16 only on the 50 main DiT attentions.
+        # The two token-refiner blocks intentionally retain the source compute dtype.
+        for block in self.blocks:
+            block.attn.fp16_qkv = True
+        self.final_layer = FinalLayer(hidden_size, time_embed_dim, video_patch_dim, audio_latents_dim,
+                                      final_norm_eps, **curve, dtype=dtype, device=device, operations=operations)
+
+    def preprocess_text_embeds(self, text_states):
+        """[B, L, text_dim] Qwen states -> [B, L, hidden] refined text embeds."""
+        if text_states.shape[-1] == self.hidden_size:
+            return text_states
+        return self.token_refiner(self.condition_proj(text_states[0])).unsqueeze(0)
+
+    def rope_freqs(self, position_ids, device):
+        # [S, 3] float64 -> [S, 96] fp32
+        pos = position_ids.to(torch.float32).to(device)
+        inv = comfy.model_management.cast_to(self.rope.inv_freq, device=device)
+        per_axis = pos.unsqueeze(-1) * inv.view(1, 1, -1)      # [S, 3, 16]
+        t_f, h_f, w_f = per_axis.unbind(dim=1)
+        half = torch.cat((t_f, h_f, w_f), dim=-1)              # [S, 48]
+        return torch.cat((half, half), dim=-1)                 # [S, 96]
+
+    def _cond_video_rows(self, payload, device):
+        """Concatenated visual condition rows (normalized latents -> patchified), with condition noise augmentation."""
+        rows = []
+        aug = payload.get("visual_cond_noise_aug", VISUAL_COND_TIMESTEP)
+        seed = int(payload.get("seed", 0))
+        # every condition intentionally restarts the same RNG stream
+        for z in payload.get("cond_video_latents", []):
+            r = patchify_video(z.to(torch.float32), self.patch_size)
+            if aug < 1.0:
+                gen = torch.Generator("cpu").manual_seed(seed)
+                noise = torch.randn(r.shape, generator=gen, dtype=torch.float32)
+                r = aug * r + (1.0 - aug) * noise.to(r.device)
+            rows.append(r.to(device))
+        return torch.cat(rows, dim=0) if rows else None
+
+    def _cond_audio_rows(self, payload, device):
+        rows = []
+        aug = payload.get("audio_cond_noise_aug", AUDIO_COND_TIMESTEP)
+        seed = int(payload.get("seed", 0)) + 1
+        for z in payload.get("cond_audio_latents", []):
+            r = pack_audio(z.to(torch.float32))
+            if aug < 1.0:
+                gen = torch.Generator("cpu").manual_seed(seed)
+                noise = torch.randn(r.shape, generator=gen, dtype=torch.float32)
+                r = aug * r + (1.0 - aug) * noise.to(r.device)
+            rows.append(r.to(device))
+        return torch.cat(rows, dim=0) if rows else None
+
+    def forward(self, x, timestep, context, transformer_options={}, minimax_payload=None, **kwargs):
+        return comfy.patcher_extension.WrapperExecutor.new_class_executor(
+            self._forward,
+            self,
+            comfy.patcher_extension.get_all_wrappers(comfy.patcher_extension.WrappersMP.DIFFUSION_MODEL, transformer_options)
+        ).execute(x, timestep, context, transformer_options, minimax_payload=minimax_payload, **kwargs)
+
+    def _forward(self, x, timestep, context, transformer_options={}, minimax_payload=None, **kwargs):
+        video_x, audio_x = x[0], x[1]
+        orig_t, orig_h, orig_w = video_x.shape[2], video_x.shape[3], video_x.shape[4]
+        video_x = comfy.ldm.common_dit.pad_to_patch_size(video_x, self.patch_size)
+        if video_x.shape[0] != 1:
+            raise ValueError("MiniMax H3 supports batch size 1")
+        payload = minimax_payload or {}
+        device = video_x.device
+        dtype = context.dtype  # compute dtype
+
+        latent_t, lat_h, lat_w = video_x.shape[2], video_x.shape[3], video_x.shape[4]
+        audio_t = audio_x.shape[-1]
+        text_len = context.shape[1]
+        # extra_conds prebuilds the layout once per sampling run
+        layout = payload.get("layout")
+        if layout is None or layout.signature != (text_len, latent_t, lat_h, lat_w, audio_t):
+            layout = PackedLayout(text_len, latent_t, lat_h, lat_w, audio_t,
+                                  keyframes=payload.get("keyframes"),
+                                  refs=payload.get("refs"),
+                                  frame_count=payload.get("frame_count"))
+
+        # model_base passes model_sampling.timestep(sigma) = sigma * 1000
+        shift_v = float(transformer_options.get("minimax_h3_sigma_shift_video", self.sigma_shift_video))
+        shift_a = float(transformer_options.get("minimax_h3_sigma_shift_audio", self.sigma_shift_audio))
+        sigma_v = (timestep.flatten()[0] / 1000.0).float().clamp(min=1e-6)
+        t_v = float(1.0 - sigma_v)
+        t_a = float(1.0 - time_shift_sigma(sigma_v, shift_v, shift_a))
+
+        # distinct timesteps are known analytically: text/pad follow video, cond rows pin near 1
+        vis_aug = float(payload.get("visual_cond_noise_aug", VISUAL_COND_TIMESTEP))
+        aud_aug = float(payload.get("audio_cond_noise_aug", AUDIO_COND_TIMESTEP))
+        has_vis_cond = any(k in ("cond", "ref_img") for _, _, k in layout.segments)
+        has_aud_cond = any(k == "ref_audio" for _, _, k in layout.segments)
+        seg_t = {"text": t_v, "video": t_v, "audio": t_a,
+                 "cond": max(t_v, vis_aug), "ref_img": max(t_v, vis_aug),
+                 "ref_audio": max(t_a, aud_aug)}
+        unique_t = sorted({t_v, t_a} | ({seg_t["cond"]} if has_vis_cond else set())
+                          | ({seg_t["ref_audio"]} if has_aud_cond else set()))
+        t_row = {t: i for i, t in enumerate(unique_t)}
+        seg_tag = {"text": 1, "video": 0, "audio": 2, "cond": 0, "ref_img": 0, "ref_audio": 2}
+
+        text_tags = payload.get("text_token_tags")
+        mod_segments = []
+        for a, b, kind in layout.segments:
+            row_base = t_row[seg_t[kind]] * 3
+            if kind == "text" and text_tags is not None:
+                # the presentation text span mixes tags (vision pads carry the video modality) split into tag runs
+                tags = text_tags.view(-1).tolist()
+                run_start = 0
+                for i in range(1, b - a + 1):
+                    if i == b - a or tags[i] != tags[run_start]:
+                        mod_segments.append((a + run_start, a + i, row_base + int(tags[run_start])))
+                        run_start = i
+            else:
+                mod_segments.append((a, b, row_base + seg_tag[kind]))
+
+        # embed
+        img_update = layout.img_update.to(device)
+        audio_update = layout.audio_update.to(device)
+        video_rows = patchify_video(video_x.to(torch.float32), self.patch_size)
+        audio_rows = pack_audio(audio_x.to(torch.float32))
+        cond_video_rows = self._cond_video_rows(payload, device)
+        cond_audio_rows = self._cond_audio_rows(payload, device)
+
+        all_video_rows = video_rows
+        if cond_video_rows is not None:
+            all_video_rows = torch.empty(img_update.shape[0], video_rows.shape[1], dtype=torch.float32, device=device)
+            all_video_rows[~img_update] = cond_video_rows
+            all_video_rows[img_update] = video_rows
+        all_audio_rows = audio_rows
+        if cond_audio_rows is not None:
+            all_audio_rows = torch.empty(audio_update.shape[0], audio_rows.shape[1], dtype=torch.float32, device=device)
+            all_audio_rows[~audio_update] = cond_audio_rows
+            all_audio_rows[audio_update] = audio_rows
+
+        video_embed = self.video_patch_proj(all_video_rows).to(dtype)
+        audio_embed = self.audio_patch_proj(all_audio_rows).to(dtype)
+        text_states = context[0]
+        if text_states.shape[-1] != self.hidden_size:
+            text_states = self.token_refiner(self.condition_proj(text_states),
+                                             transformer_options=transformer_options)
+
+        # segments are contiguous: assemble by slices, embed rows follow segment order
+        h = torch.empty(layout.seq_len, self.hidden_size, dtype=dtype, device=device)
+        voff = aoff = 0
+        for a, b, kind in layout.segments:
+            n = b - a
+            if kind == "text":
+                h[a:b] = text_states
+            elif kind in ("cond", "ref_img", "video"):
+                h[a:b] = video_embed[voff:voff + n]
+                voff += n
+            else:  # ref_audio / audio
+                h[a:b] = audio_embed[aoff:aoff + n]
+                aoff += n
+
+        t_vals = torch.tensor(unique_t, dtype=torch.float32, device=device)
+        if self.use_adaln_curves:
+            # adaln projections consume interpolated coordinates of the time-embedding curve
+            table = comfy.model_management.cast_to(self.adaln_t_table, device=device)
+            pos = t_vals.clamp(0.0, 1.0) * (table.shape[0] - 1)     # t in [0,1] -> fractional grid index, out-of-range t clamps to the curve ends
+            i0 = pos.floor().long().clamp(max=table.shape[0] - 2)   # lower grid row, max-clamp keeps t=1.0 on the last interval instead of reading past the table
+            t_emb = torch.lerp(table[i0], table[i0 + 1], (pos - i0).unsqueeze(1))  # blend the two rows by the fractional part
+        else:
+            t_emb = self.time_embedder(t_vals).to(dtype)
+
+        # rotation table computed once per forward, consumed by the kitchen split-half rope
+        rope_freqs = rope_rotation_table(self.rope_freqs(layout.position_ids, device), dtype)
+
+        # blocks
+        patches_replace = transformer_options.get("patches_replace", {})
+        blocks_replace = patches_replace.get("dit", {})
+        prefetch_queue = comfy.model_prefetch.make_prefetch_queue(list(self.blocks), device, transformer_options)
+        for i, block in enumerate(self.blocks):
+            comfy.model_prefetch.prefetch_queue_pop(prefetch_queue, device, block)
+            if ("double_block", i) in blocks_replace:
+                def block_wrap(args):
+                    return {"img": block(args["img"], args["t_emb"], args["mod_segments"], args["rope_freqs"],
+                                         transformer_options=args["transformer_options"])}
+                h = blocks_replace[("double_block", i)](
+                    {"img": h, "t_emb": t_emb, "mod_segments": mod_segments, "rope_freqs": rope_freqs,
+                     "transformer_options": transformer_options},
+                    {"original_block": block_wrap})["img"]
+            else:
+                h = block(h, t_emb, mod_segments, rope_freqs, transformer_options=transformer_options)
+        if prefetch_queue is not None:
+            comfy.model_prefetch.prefetch_queue_pop(prefetch_queue, device, None)
+
+        # target streams are single contiguous segments (audio then video, last two)
+        video_seg = next((a, b, t_row[seg_t["video"]]) for a, b, k in layout.segments if k == "video")
+        audio_seg = next((a, b, t_row[seg_t["audio"]]) for a, b, k in layout.segments if k == "audio")
+        v, a = self.final_layer(h, t_emb, video_seg, audio_seg)
+
+        video_out = unpatchify_video(v, latent_t, lat_h // 2, lat_w // 2, self.latents_dim, self.patch_size)
+        video_out = video_out[:, :, :orig_t, :orig_h, :orig_w]
+        audio_out = unpack_audio(a)
+
+        # The sampler integrates the flat ODE dX/dsigma_v = (X - denoised)/sigma_v.
+        # Scaling the audio velocity by d(sigma_a)/d(sigma_v) makes that ODE equal
+        # to the audio stream's true ODE on its own shifted schedule.
+        slope_a = time_shift_slope(sigma_v, shift_v, shift_a).to(audio_out.dtype)
+        return [-video_out.to(video_x.dtype), (-slope_a) * audio_out.to(audio_x.dtype)]

--- a/sources/te_v100/model.py
+++ b/sources/te_v100/model.py
@@ -1,0 +1,693 @@
+"""MiniMax H3 audio-video DiT.
+
+Single-stream packed-token transformer denoising video (24ch, patch 1x2x2) and
+stereo audio (32ch, 40 Hz) latents jointly, conditioned on Qwen3-VL layer-50 hidden states.
+The packed sequence is:
+[text | cond rows | audio | video] for t2va/fl2va
+[text | reference blocks | audio | video] for ref2va
+
+Timestep domain: the model receives the *video* sigma from the sampler and
+derives per-token timesteps t = 1 - sigma internally; the audio stream runs on
+its own shifted schedule (sigma_shift video 12.0 / audio 3.0), mapped from the
+video sigma in closed form. The audio velocity is returned scaled by the
+schedule map's derivative d(sigma_a)/d(sigma_v).
+"""
+
+import math
+
+import torch
+import torch.nn as nn
+
+import comfy.ldm.common_dit
+import comfy.model_management
+import comfy.model_prefetch
+import comfy.ops
+import comfy.patcher_extension
+import comfy.quant_ops
+from comfy.ldm.modules.attention import optimized_attention
+
+FRAME_PER_TOKEN = (1, 4, 4, 4, 4)
+FRAME_RESCALE = 5.0 / 3.0
+VISUAL_COND_TIMESTEP = 0.999
+AUDIO_COND_TIMESTEP = 1.0
+
+
+def time_shift_sigma(sigma, from_shift, to_shift):
+    # invert sigma = s*b/(1+(s-1)*b) to the base grid, re-apply the other shift
+    base = sigma / (from_shift + sigma * (1.0 - from_shift))
+    return to_shift * base / (1.0 + (to_shift - 1.0) * base)
+
+
+def time_shift_slope(sigma, from_shift, to_shift):
+    """d(sigma_to)/d(sigma_from) at the same base-grid point.
+
+    Scaling a stream's returned velocity by this slope makes the flat ODE that
+    any sampler integrates on the from-schedule equal to that stream's true ODE
+    on its own schedule.
+    """
+    base = sigma / (from_shift + sigma * (1.0 - from_shift))
+    return (to_shift * (1.0 + (from_shift - 1.0) * base) ** 2) / (from_shift * (1.0 + (to_shift - 1.0) * base) ** 2)
+
+
+def patchify_video(latent, patch_size=(1, 2, 2)):
+    # [B, C, T, H, W] -> [B*t*h*w, C*pt*ph*pw]
+    b, c, t_full, h_full, w_full = latent.shape
+    pt, ph, pw = patch_size
+    t, h, w = t_full // pt, h_full // ph, w_full // pw
+    x = latent.reshape(b, c, t, pt, h, ph, w, pw)
+    x = torch.einsum("nctrhpwq->nthwcrpq", x)
+    return x.reshape(b * t * h * w, c * pt * ph * pw)
+
+
+def unpatchify_video(rows, t, h, w, c=24, patch_size=(1, 2, 2)):
+    pt, ph, pw = patch_size
+    x = rows.reshape(-1, t, h, w, c, pt, ph, pw)
+    x = torch.einsum("nthwcrpq->nctrhpwq", x)
+    return x.reshape(-1, c, t * pt, h * ph, w * pw)
+
+
+def pack_audio(latent):
+    # [B, C=32, ch=2, T] -> [ch*T, 32] channel-major (ch0 t0..T-1, ch1 t0..T-1)
+    b, c, ch, t = latent.shape
+    return latent[0].permute(1, 2, 0).reshape(ch * t, c)
+
+
+def unpack_audio(rows, ch=2):
+    t = rows.shape[0] // ch
+    return rows.reshape(ch, t, rows.shape[-1]).permute(2, 0, 1).unsqueeze(0)
+
+
+def _axis_from_sqrt_area(dim, patch, sqrt_area):
+    # linspace((1 - ratio) / 2, (1 + ratio) / 2, dim // patch, endpoint=False) * 32
+    ratio = dim / sqrt_area
+    n = dim // patch
+    return (torch.arange(n, dtype=torch.float64) * (ratio / n) + (1.0 - ratio) / 2.0) * 32.0
+
+
+def _frame_grid(h, w):
+    # area-normalized (h, w) coordinates of one latent frame's 2x2-patch rows
+    area = math.sqrt(h * w)
+    hh, ww = torch.meshgrid(_axis_from_sqrt_area(h, 2, area), _axis_from_sqrt_area(w, 2, area), indexing="ij")
+    return torch.stack([hh.reshape(-1), ww.reshape(-1)], dim=-1), _axis_from_sqrt_area(w, 2, area)
+
+
+def _video_t_spans(n):
+    return [FRAME_RESCALE * FRAME_PER_TOKEN[k % 5] for k in range(n)]
+
+
+def _video_t_grid(n, origin):
+    # origin + exclusive cumsum
+    spans = torch.tensor(_video_t_spans(n), dtype=torch.float64)
+    return float(origin) + torch.cat([torch.zeros(1, dtype=torch.float64), spans[:-1].cumsum(0)])
+
+
+def _audio_grid(cursor, t, w_low, w_high):
+    # channel-major stereo rows: t advances per latent frame, w pinned to the grid extremes per stereo channel, h stays 0
+    g = torch.zeros(t * 2, 3, dtype=torch.float64)
+    g[:, 0] = (cursor + torch.arange(t, dtype=torch.float64)).repeat(2)
+    g[:t, 2] = w_low
+    g[t:, 2] = w_high
+    return g
+
+
+def _video_grid(vt, frame, cursor):
+    g = torch.empty(vt, frame.shape[0], 3, dtype=torch.float64)
+    g[:, :, 0] = _video_t_grid(vt, cursor)[:, None]
+    g[:, :, 1:] = frame[None]
+    return g.reshape(-1, 3)
+
+
+class TimeEmbedder(nn.Module):
+    def __init__(self, freq_dim, hidden, out, dtype=None, device=None, operations=None):
+        super().__init__()
+        self.freq_dim = freq_dim
+        self.proj_in = operations.Linear(freq_dim, hidden, bias=True, dtype=dtype, device=device)
+        self.proj_out = operations.Linear(hidden, out, bias=True, dtype=dtype, device=device)
+
+    def forward(self, t):
+        # t: [M] in [0, 1]; fp32 throughout, cos before sin
+        half = self.freq_dim // 2
+        freqs = torch.exp(-math.log(10000.0) * torch.arange(half, dtype=torch.float32, device=t.device) / half)
+        args = t.to(torch.float32)[:, None] * freqs[None]
+        emb = torch.cat([torch.cos(args), torch.sin(args)], dim=-1)
+        return self.proj_out(nn.functional.silu(self.proj_in(emb)))
+
+
+def rope_rotation_table(angles, dtype):
+    """[S, rot_dim] pair angles -> [1, S, 1, rot_dim/2, 2, 2] rotation matrices."""
+    half = angles.shape[-1] // 2
+    ang = angles[:, :half]  # duplicated halves: [:, :half] == [:, half:]
+    c, s = torch.cos(ang), torch.sin(ang)
+    table = torch.stack([c, -s, s, c], dim=-1).reshape(1, angles.shape[0], 1, half, 2, 2)
+    return table.to(dtype)
+
+
+class Attention(nn.Module):
+    def __init__(self, hidden, heads, head_dim, eps, dtype=None, device=None, operations=None):
+        super().__init__()
+        self.heads = heads
+        self.head_dim = head_dim
+        inner = heads * head_dim
+        self.qkv_proj = operations.Linear(hidden, inner * 3, bias=False, dtype=dtype, device=device)
+        self.q_norm = operations.RMSNorm(head_dim, eps=eps, dtype=dtype, device=device)
+        self.k_norm = operations.RMSNorm(head_dim, eps=eps, dtype=dtype, device=device)
+        self.out_proj = operations.Linear(inner, hidden, bias=False, dtype=dtype, device=device)
+
+    def forward(self, x, rope_freqs=None, transformer_options={}):
+        s = x.shape[0]
+        residual_dtype = x.dtype
+        use_fp16 = (
+            getattr(self, "fp16_qkv", False)
+            and x.device.type == "cuda"
+            and x.dtype == torch.float32
+        )
+
+        # MiniMax H3 V100 acceleration (tested Plan 2): QKV projection and
+        # attention use FP16 Tensor Cores. Q/K return to FP32 immediately for
+        # RMSNorm and RoPE. Output projection, MLP, AdaLN and residual stay FP32.
+        proj_x = x.half() if use_fp16 else x
+        q, k, v = self.qkv_proj(proj_x).split(self.heads * self.head_dim, dim=-1)
+        if use_fp16:
+            q = q.float()
+            k = k.float()
+        v = v.view(s, self.heads, self.head_dim)
+        if rope_freqs is not None:
+            q = q.view(1, s, self.heads, self.head_dim)
+            k = k.view(1, s, self.heads, self.head_dim)
+            qw = comfy.model_management.cast_to(self.q_norm.weight, dtype=q.dtype, device=x.device)
+            kw = comfy.model_management.cast_to(self.k_norm.weight, dtype=k.dtype, device=x.device)
+            rope = rope_freqs.to(q.dtype) if rope_freqs.dtype != q.dtype else rope_freqs
+            rot = rope.shape[-3] * 2
+            if comfy.model_management.in_training:
+                q, k = comfy.quant_ops.ck.rms_rope_split_half(
+                    q, k, rope, qw, kw, epsilon=self.q_norm.eps, rot_dim=rot)
+            else:
+                comfy.quant_ops.ck.rms_rope_split_half_(
+                    q, k, rope, qw, kw, epsilon=self.q_norm.eps, rot_dim=rot)
+            q = q[0]
+            k = k[0]
+        else:
+            q = self.q_norm(q.view(s, self.heads, self.head_dim))
+            k = self.k_norm(k.view(s, self.heads, self.head_dim))
+        q = q.transpose(0, 1).unsqueeze(0)
+        k = k.transpose(0, 1).unsqueeze(0)
+        v = v.transpose(0, 1).unsqueeze(0)
+
+        if use_fp16:
+            out = optimized_attention(
+                q.half(), k.half(), v.half(), self.heads, mask=None,
+                skip_reshape=True, transformer_options=transformer_options,
+            ).to(residual_dtype)
+        else:
+            out = optimized_attention(
+                q, k, v, self.heads, mask=None, skip_reshape=True,
+                transformer_options=transformer_options,
+            )
+        return self.out_proj(out.squeeze(0))
+
+
+class MLP(nn.Module):
+    def __init__(self, hidden, ffn, dtype=None, device=None, operations=None):
+        super().__init__()
+        self.fc1 = operations.Linear(hidden, ffn * 2, bias=False, dtype=dtype, device=device)
+        self.fc2 = operations.Linear(ffn, hidden, bias=False, dtype=dtype, device=device)
+
+    def forward(self, x):
+        return comfy.ops.linear_input_act(self.fc2, self.fc1(x), "swiglu")
+
+
+class AdalnProj(nn.Module):
+    def __init__(self, t_dim, hidden, expand, modalities, apply_silu=True,
+                 dtype=None, device=None, operations=None):
+        super().__init__()
+        self.expand = expand
+        self.modalities = modalities
+        self.hidden = hidden
+        self.apply_silu = apply_silu
+        self.linear = operations.Linear(t_dim, expand * hidden * modalities, bias=True, dtype=dtype, device=device)
+
+    def forward(self, t_emb):
+        # [M, t_dim] -> expand tensors of [M*modalities, hidden]
+        x = self.linear(nn.functional.silu(t_emb) if self.apply_silu else t_emb)
+        x = x.view(x.shape[0] * self.modalities, self.expand * self.hidden)
+        return x.chunk(self.expand, dim=-1)
+
+
+def _mod_scale_shift(h, shift, scale, segments):
+    # segments: [(start, stop, mod_row)] covering h contiguously.
+    for a, b, row in segments:
+        h[a:b].mul_(1.0 + scale[row].to(h.dtype)).add_(shift[row].to(h.dtype))
+    return h
+
+
+def _mod_gate(x, gate, other, segments):
+    # other is the fresh attn/mlp output: accumulate the gated residual into the stream in place, one fused kernel per segment
+    for a, b, row in segments:
+        x[a:b].addcmul_(other[a:b], gate[row].to(x.dtype))
+    return x
+
+
+class RefinerBlock(nn.Module):
+    def __init__(self, hidden, heads, head_dim, ffn, eps, qk_eps, dtype=None, device=None, operations=None):
+        super().__init__()
+        self.norm1 = operations.RMSNorm(hidden, eps=eps, dtype=dtype, device=device)
+        self.norm2 = operations.RMSNorm(hidden, eps=eps, dtype=dtype, device=device)
+        self.attn = Attention(hidden, heads, head_dim, qk_eps, dtype=dtype, device=device, operations=operations)
+        self.mlp = MLP(hidden, ffn, dtype=dtype, device=device, operations=operations)
+
+    def forward(self, x, transformer_options={}):
+        # attn/mlp outputs are fresh: accumulate residuals in place
+        x = self.attn(self.norm1(x), transformer_options=transformer_options).add_(x)
+        return self.mlp(self.norm2(x)).add_(x)
+
+
+class TokenRefiner(nn.Module):
+    def __init__(self, num_layers, hidden, heads, head_dim, ffn, eps, qk_eps, final_eps,
+                 dtype=None, device=None, operations=None):
+        super().__init__()
+        self.blocks = nn.ModuleList([
+            RefinerBlock(hidden, heads, head_dim, ffn, eps, qk_eps, dtype=dtype, device=device, operations=operations)
+            for _ in range(num_layers)])
+        self.final_norm = operations.RMSNorm(hidden, eps=final_eps, dtype=dtype, device=device)
+
+    def forward(self, x, transformer_options={}):
+        for block in self.blocks:
+            x = block(x, transformer_options=transformer_options)
+        return self.final_norm(x)
+
+
+class DiTBlock(nn.Module):
+    def __init__(self, hidden, heads, head_dim, ffn, t_dim, eps, qk_eps,
+                 apply_silu=True, adaln_dtype=None, dtype=None, device=None, operations=None):
+        super().__init__()
+        self.norm1 = operations.RMSNorm(hidden, eps=eps, dtype=dtype, device=device)
+        self.norm2 = operations.RMSNorm(hidden, eps=eps, dtype=dtype, device=device)
+        self.attn = Attention(hidden, heads, head_dim, qk_eps, dtype=dtype, device=device, operations=operations)
+        self.mlp = MLP(hidden, ffn, dtype=dtype, device=device, operations=operations)
+        self.adaln_proj = AdalnProj(t_dim, hidden, 6, 3, apply_silu=apply_silu,
+                                    dtype=adaln_dtype if adaln_dtype is not None else dtype,
+                                    device=device, operations=operations)
+
+    def forward(self, x, t_emb, mod_segments, rope_freqs, transformer_options={}):
+        shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = self.adaln_proj(t_emb)
+        h = _mod_scale_shift(self.norm1(x), shift_msa, scale_msa, mod_segments)
+        x = _mod_gate(x, gate_msa, self.attn(h, rope_freqs=rope_freqs, transformer_options=transformer_options), mod_segments)
+        h = _mod_scale_shift(self.norm2(x), shift_mlp, scale_mlp, mod_segments)
+        return _mod_gate(x, gate_mlp, self.mlp(h), mod_segments)
+
+
+class FinalLayer(nn.Module):
+    def __init__(self, hidden, t_dim, video_dim, audio_dim, eps, apply_silu=True, adaln_dtype=None,
+                 dtype=None, device=None, operations=None):
+        super().__init__()
+        self.norm = operations.RMSNorm(hidden, eps=eps, dtype=dtype, device=device)
+        self.adaln_proj = AdalnProj(t_dim, hidden, 2, 1, apply_silu=apply_silu,
+                                    dtype=adaln_dtype if adaln_dtype is not None else dtype,
+                                    device=device, operations=operations)
+        # output heads are the checkpoint's fp32 island; norm/adaln are stored at model dtype
+        self.video_out = operations.Linear(hidden, video_dim, bias=True, dtype=torch.float32, device=device)
+        self.audio_out = operations.Linear(hidden, audio_dim, bias=True, dtype=torch.float32, device=device)
+
+    def forward(self, x, t_emb, video_seg, audio_seg):
+        # video_seg / audio_seg: (start, stop, timestep_row) of the target streams
+        shift, scale = self.adaln_proj(t_emb)
+        va, vb, vrow = video_seg
+        aa, ab, arow = audio_seg
+        hv = (self.norm(x[va:vb]) * (1.0 + scale[vrow]) + shift[vrow]).to(torch.float32)
+        ha = (self.norm(x[aa:ab]) * (1.0 + scale[arow]) + shift[arow]).to(torch.float32)
+        return self.video_out(hv), self.audio_out(ha)
+
+
+class PackedLayout:
+    """Static packed-sequence structure for one shape/conditioning signature."""
+
+    def __init__(self, text_len, latent_t, latent_h, latent_w, audio_t, keyframes=None, refs=None, frame_count=None):
+        frame, w_grid = _frame_grid(latent_h, latent_w)
+        frame_rows = frame.shape[0]
+
+        segments = [("text", text_len)]  # (kind, n_rows)
+        g = torch.zeros(text_len, 3, dtype=torch.float64)
+        g[:, 0] = torch.arange(text_len, dtype=torch.float64)
+        pos = [g]  # per segment: [n, 3] float64 (t, h, w)
+
+        img_pos, img_update = [], []
+        audio_pos, audio_update = [], []
+        cursor = text_len
+        row = text_len
+
+        if keyframes:
+            # fl2va: keyframe cond rows right after text, sharing the target spatial grid
+            for kf in keyframes:
+                pixel_index = kf["resolved_frame_index"]
+                if pixel_index == 0:
+                    cond_t = float(text_len)
+                elif frame_count is not None and pixel_index == frame_count - 1:
+                    cond_t = float(text_len) + sum(_video_t_spans(latent_t)) - FRAME_RESCALE
+                else:
+                    raise ValueError("only first/last keyframe anchors are supported")
+                g = torch.empty(frame_rows, 3, dtype=torch.float64)
+                g[:, 0] = cond_t
+                g[:, 1:] = frame
+                segments.append(("cond", frame_rows))
+                pos.append(g)
+                img_pos.append(torch.arange(row, row + frame_rows))
+                img_update.append(torch.zeros(frame_rows, dtype=torch.bool))
+                row += frame_rows
+
+        target_audio_w = (float(w_grid[0]), float(w_grid[-1]))
+        if refs:
+            cursor = float(text_len)
+            for blk in refs:
+                kind = blk["kind"]
+                if kind == "image":
+                    r_frame, _ = _frame_grid(blk["latent_h"], blk["latent_w"])
+                    n = r_frame.shape[0]
+                    g = torch.empty(n, 3, dtype=torch.float64)
+                    g[:, 0] = cursor
+                    g[:, 1:] = r_frame
+                    segments.append(("ref_img", n))
+                    pos.append(g)
+                    img_pos.append(torch.arange(row, row + n))
+                    img_update.append(torch.zeros(n, dtype=torch.bool))
+                    row += n
+                    cursor += 1.0
+                elif kind == "audio":
+                    rt = blk["ref_audio_t"]
+                    if rt > 0:
+                        segments.append(("ref_audio", rt * 2))
+                        pos.append(_audio_grid(cursor, rt, *target_audio_w))
+                        audio_pos.append(torch.arange(row, row + rt * 2))
+                        audio_update.append(torch.zeros(rt * 2, dtype=torch.bool))
+                        row += rt * 2
+                    cursor += float(rt)
+                elif kind in ("video", "video_audio"):
+                    # the block's audio rows pack immediately before its video
+                    # rows, both sharing the cursor origin
+                    rt = blk["ref_audio_t"]
+                    vt = blk["latent_t"]
+                    r_frame, r_w_grid = _frame_grid(blk["latent_h"], blk["latent_w"])
+                    if rt > 0:
+                        segments.append(("ref_audio", rt * 2))
+                        pos.append(_audio_grid(cursor, rt, float(r_w_grid[0]), float(r_w_grid[-1])))
+                        audio_pos.append(torch.arange(row, row + rt * 2))
+                        audio_update.append(torch.zeros(rt * 2, dtype=torch.bool))
+                        row += rt * 2
+                    n = vt * r_frame.shape[0]
+                    segments.append(("ref_img", n))
+                    pos.append(_video_grid(vt, r_frame, cursor))
+                    img_pos.append(torch.arange(row, row + n))
+                    img_update.append(torch.zeros(n, dtype=torch.bool))
+                    row += n
+                    cursor += max(float(rt), sum(_video_t_spans(vt)))
+
+        # target audio then target video, always the last two segments
+        segments.append(("audio", audio_t * 2))
+        pos.append(_audio_grid(cursor, audio_t, *target_audio_w))
+        audio_pos.append(torch.arange(row, row + audio_t * 2))
+        audio_update.append(torch.ones(audio_t * 2, dtype=torch.bool))
+        row += audio_t * 2
+
+        n_video = latent_t * frame_rows
+        segments.append(("video", n_video))
+        pos.append(_video_grid(latent_t, frame, cursor))
+        img_pos.append(torch.arange(row, row + n_video))
+        img_update.append(torch.ones(n_video, dtype=torch.bool))
+        row += n_video
+
+        self.seq_len = row
+        self.position_ids = torch.cat(pos)  # [S, 3] float64
+        self.img_pos = torch.cat(img_pos)
+        self.img_update = torch.cat(img_update)
+        self.audio_pos = torch.cat(audio_pos)
+        self.audio_update = torch.cat(audio_update)
+        self.signature = (text_len, latent_t, latent_h, latent_w, audio_t)
+        # contiguous segment table (start, stop, kind)
+        # kinds: text / cond / ref_img / ref_audio / audio / video
+        # the packed sequence is uniform per segment in (modality tag, timestep class),
+        # except the text span (tag runs resolved at forward time from the presentation tags)
+        seg_abs = []
+        off = 0
+        for kind, n in segments:
+            seg_abs.append((off, off + n, kind))
+            off += n
+        self.segments = seg_abs
+
+
+class MiniMaxH3Model(nn.Module):
+    def __init__(self, hidden_size=5376, num_layers=50, token_refiner_num_layers=2,
+                 num_attention_heads=56, attention_head_dim=128, ffn_hidden_size=14336,
+                 latents_dim=24, audio_latents_dim=32, patch_size=(1, 2, 2), text_dim=5120,
+                 timestep_input_dim=256, time_embed_hidden_size=5376, time_embed_dim=2688,
+                 rope_inv_freq_len=16, norm_eps=1e-5, qk_norm_eps=1e-5, final_norm_eps=1e-5,
+                 sigma_shift_video=12.0, sigma_shift_audio=3.0,
+                 adaln_curve_grid=None,
+                 image_model=None, dtype=None, device=None, operations=None, **kwargs):
+        super().__init__()
+        self.dtype = dtype
+        self.hidden_size = hidden_size
+        self.patch_size = tuple(patch_size)
+        self.latents_dim = latents_dim
+        self.audio_latents_dim = audio_latents_dim
+        self.sigma_shift_video = sigma_shift_video
+        self.sigma_shift_audio = sigma_shift_audio
+        self.use_adaln_curves = adaln_curve_grid is not None
+        # curve-form checkpoints replace the time embedder and full-width adaln weights with a small shared basis of the time-embedding curve
+        curve = {"apply_silu": not self.use_adaln_curves,
+                 "adaln_dtype": torch.float32 if self.use_adaln_curves else dtype}
+        video_patch_dim = latents_dim * self.patch_size[0] * self.patch_size[1] * self.patch_size[2]
+
+        self.video_patch_proj = operations.Linear(video_patch_dim, hidden_size, bias=True, dtype=torch.float32, device=device)
+        self.audio_patch_proj = operations.Linear(audio_latents_dim, hidden_size, bias=True, dtype=torch.float32, device=device)
+        self.condition_proj = operations.Linear(text_dim, hidden_size, bias=True, dtype=dtype, device=device)
+        if self.use_adaln_curves:
+            self.register_buffer("adaln_t_table", torch.empty(adaln_curve_grid, time_embed_dim, dtype=torch.float32))
+        else:
+            self.time_embedder = TimeEmbedder(timestep_input_dim, time_embed_hidden_size, time_embed_dim,
+                                              dtype=torch.float32, device=device, operations=operations)
+        self.rope = nn.Module()
+        self.rope.register_buffer("inv_freq", torch.empty(rope_inv_freq_len, dtype=torch.float32))
+        self.token_refiner = TokenRefiner(token_refiner_num_layers, hidden_size, num_attention_heads,
+                                          attention_head_dim, ffn_hidden_size, norm_eps, qk_norm_eps,
+                                          final_norm_eps, dtype=dtype, device=device, operations=operations)
+        self.blocks = nn.ModuleList([
+            DiTBlock(hidden_size, num_attention_heads, attention_head_dim, ffn_hidden_size,
+                     time_embed_dim, norm_eps, qk_norm_eps, **curve, dtype=dtype, device=device, operations=operations)
+            for _ in range(num_layers)])
+        # MiniMax H3 V100 Plan 2: enable FP16 only on the 50 main DiT attentions.
+        # The two token-refiner blocks intentionally retain the source compute dtype.
+        for block in self.blocks:
+            block.attn.fp16_qkv = True
+        self.final_layer = FinalLayer(hidden_size, time_embed_dim, video_patch_dim, audio_latents_dim,
+                                      final_norm_eps, **curve, dtype=dtype, device=device, operations=operations)
+
+    def preprocess_text_embeds(self, text_states):
+        """[B, L, text_dim] Qwen states -> [B, L, hidden] refined text embeds."""
+        if text_states.shape[-1] == self.hidden_size:
+            return text_states
+        return self.token_refiner(self.condition_proj(text_states[0])).unsqueeze(0)
+
+    def rope_freqs(self, position_ids, device):
+        # [S, 3] float64 -> [S, 96] fp32
+        pos = position_ids.to(torch.float32).to(device)
+        inv = comfy.model_management.cast_to(self.rope.inv_freq, device=device)
+        per_axis = pos.unsqueeze(-1) * inv.view(1, 1, -1)      # [S, 3, 16]
+        t_f, h_f, w_f = per_axis.unbind(dim=1)
+        half = torch.cat((t_f, h_f, w_f), dim=-1)              # [S, 48]
+        return torch.cat((half, half), dim=-1)                 # [S, 96]
+
+    def _cond_video_rows(self, payload, device):
+        """Concatenated visual condition rows (normalized latents -> patchified), with condition noise augmentation."""
+        rows = []
+        aug = payload.get("visual_cond_noise_aug", VISUAL_COND_TIMESTEP)
+        seed = int(payload.get("seed", 0))
+        # every condition intentionally restarts the same RNG stream
+        for z in payload.get("cond_video_latents", []):
+            r = patchify_video(z.to(torch.float32), self.patch_size)
+            if aug < 1.0:
+                gen = torch.Generator("cpu").manual_seed(seed)
+                noise = torch.randn(r.shape, generator=gen, dtype=torch.float32)
+                r = aug * r + (1.0 - aug) * noise.to(r.device)
+            rows.append(r.to(device))
+        return torch.cat(rows, dim=0) if rows else None
+
+    def _cond_audio_rows(self, payload, device):
+        rows = []
+        aug = payload.get("audio_cond_noise_aug", AUDIO_COND_TIMESTEP)
+        seed = int(payload.get("seed", 0)) + 1
+        for z in payload.get("cond_audio_latents", []):
+            r = pack_audio(z.to(torch.float32))
+            if aug < 1.0:
+                gen = torch.Generator("cpu").manual_seed(seed)
+                noise = torch.randn(r.shape, generator=gen, dtype=torch.float32)
+                r = aug * r + (1.0 - aug) * noise.to(r.device)
+            rows.append(r.to(device))
+        return torch.cat(rows, dim=0) if rows else None
+
+    def _run_blocks(self, h, t_emb, mod_segments, rope_freqs, transformer_options, start=0, end=None):
+        patches_replace = transformer_options.get("patches_replace", {})
+        blocks_replace = patches_replace.get("dit", {})
+        end = len(self.blocks) if end is None else end
+        prefetch_queue = comfy.model_prefetch.make_prefetch_queue(list(self.blocks[start:end]), h.device, transformer_options)
+        for i in range(start, end):
+            block = self.blocks[i]
+            comfy.model_prefetch.prefetch_queue_pop(prefetch_queue, h.device, block)
+            if ("double_block", i) in blocks_replace:
+                def block_wrap(args):
+                    return {"img": block(args["img"], args["t_emb"], args["mod_segments"], args["rope_freqs"],
+                                         transformer_options=args["transformer_options"])}
+                h = blocks_replace[("double_block", i)](
+                    {"img": h, "t_emb": t_emb, "mod_segments": mod_segments, "rope_freqs": rope_freqs,
+                     "transformer_options": transformer_options},
+                    {"original_block": block_wrap})["img"]
+            else:
+                h = block(h, t_emb, mod_segments, rope_freqs, transformer_options=transformer_options)
+        if prefetch_queue is not None:
+            comfy.model_prefetch.prefetch_queue_pop(prefetch_queue, h.device, None)
+        return h
+
+    def forward(self, x, timestep, context, transformer_options={}, minimax_payload=None, **kwargs):
+        return comfy.patcher_extension.WrapperExecutor.new_class_executor(
+            self._forward,
+            self,
+            comfy.patcher_extension.get_all_wrappers(comfy.patcher_extension.WrappersMP.DIFFUSION_MODEL, transformer_options)
+        ).execute(x, timestep, context, transformer_options, minimax_payload=minimax_payload, **kwargs)
+
+    def _forward(self, x, timestep, context, transformer_options={}, minimax_payload=None, **kwargs):
+        video_x, audio_x = x[0], x[1]
+        orig_t, orig_h, orig_w = video_x.shape[2], video_x.shape[3], video_x.shape[4]
+        video_x = comfy.ldm.common_dit.pad_to_patch_size(video_x, self.patch_size)
+        if video_x.shape[0] != 1:
+            raise ValueError("MiniMax H3 supports batch size 1")
+        payload = minimax_payload or {}
+        device = video_x.device
+        dtype = context.dtype  # compute dtype
+
+        latent_t, lat_h, lat_w = video_x.shape[2], video_x.shape[3], video_x.shape[4]
+        audio_t = audio_x.shape[-1]
+        text_len = context.shape[1]
+        # extra_conds prebuilds the layout once per sampling run
+        layout = payload.get("layout")
+        if layout is None or layout.signature != (text_len, latent_t, lat_h, lat_w, audio_t):
+            layout = PackedLayout(text_len, latent_t, lat_h, lat_w, audio_t,
+                                  keyframes=payload.get("keyframes"),
+                                  refs=payload.get("refs"),
+                                  frame_count=payload.get("frame_count"))
+
+        # model_base passes model_sampling.timestep(sigma) = sigma * 1000
+        shift_v = float(transformer_options.get("minimax_h3_sigma_shift_video", self.sigma_shift_video))
+        shift_a = float(transformer_options.get("minimax_h3_sigma_shift_audio", self.sigma_shift_audio))
+        sigma_v = (timestep.flatten()[0] / 1000.0).float().clamp(min=1e-6)
+        t_v = float(1.0 - sigma_v)
+        t_a = float(1.0 - time_shift_sigma(sigma_v, shift_v, shift_a))
+
+        # distinct timesteps are known analytically: text/pad follow video, cond rows pin near 1
+        vis_aug = float(payload.get("visual_cond_noise_aug", VISUAL_COND_TIMESTEP))
+        aud_aug = float(payload.get("audio_cond_noise_aug", AUDIO_COND_TIMESTEP))
+        has_vis_cond = any(k in ("cond", "ref_img") for _, _, k in layout.segments)
+        has_aud_cond = any(k == "ref_audio" for _, _, k in layout.segments)
+        seg_t = {"text": t_v, "video": t_v, "audio": t_a,
+                 "cond": max(t_v, vis_aug), "ref_img": max(t_v, vis_aug),
+                 "ref_audio": max(t_a, aud_aug)}
+        unique_t = sorted({t_v, t_a} | ({seg_t["cond"]} if has_vis_cond else set())
+                          | ({seg_t["ref_audio"]} if has_aud_cond else set()))
+        t_row = {t: i for i, t in enumerate(unique_t)}
+        seg_tag = {"text": 1, "video": 0, "audio": 2, "cond": 0, "ref_img": 0, "ref_audio": 2}
+
+        text_tags = payload.get("text_token_tags")
+        mod_segments = []
+        for a, b, kind in layout.segments:
+            row_base = t_row[seg_t[kind]] * 3
+            if kind == "text" and text_tags is not None:
+                # the presentation text span mixes tags (vision pads carry the video modality) split into tag runs
+                tags = text_tags.view(-1).tolist()
+                run_start = 0
+                for i in range(1, b - a + 1):
+                    if i == b - a or tags[i] != tags[run_start]:
+                        mod_segments.append((a + run_start, a + i, row_base + int(tags[run_start])))
+                        run_start = i
+            else:
+                mod_segments.append((a, b, row_base + seg_tag[kind]))
+
+        # embed
+        img_update = layout.img_update.to(device)
+        audio_update = layout.audio_update.to(device)
+        video_rows = patchify_video(video_x.to(torch.float32), self.patch_size)
+        audio_rows = pack_audio(audio_x.to(torch.float32))
+        cond_video_rows = self._cond_video_rows(payload, device)
+        cond_audio_rows = self._cond_audio_rows(payload, device)
+
+        all_video_rows = video_rows
+        if cond_video_rows is not None:
+            all_video_rows = torch.empty(img_update.shape[0], video_rows.shape[1], dtype=torch.float32, device=device)
+            all_video_rows[~img_update] = cond_video_rows
+            all_video_rows[img_update] = video_rows
+        all_audio_rows = audio_rows
+        if cond_audio_rows is not None:
+            all_audio_rows = torch.empty(audio_update.shape[0], audio_rows.shape[1], dtype=torch.float32, device=device)
+            all_audio_rows[~audio_update] = cond_audio_rows
+            all_audio_rows[audio_update] = audio_rows
+
+        video_embed = self.video_patch_proj(all_video_rows).to(dtype)
+        audio_embed = self.audio_patch_proj(all_audio_rows).to(dtype)
+        text_states = context[0]
+        if text_states.shape[-1] != self.hidden_size:
+            text_states = self.token_refiner(self.condition_proj(text_states),
+                                             transformer_options=transformer_options)
+
+        # segments are contiguous: assemble by slices, embed rows follow segment order
+        h = torch.empty(layout.seq_len, self.hidden_size, dtype=dtype, device=device)
+        voff = aoff = 0
+        for a, b, kind in layout.segments:
+            n = b - a
+            if kind == "text":
+                h[a:b] = text_states
+            elif kind in ("cond", "ref_img", "video"):
+                h[a:b] = video_embed[voff:voff + n]
+                voff += n
+            else:  # ref_audio / audio
+                h[a:b] = audio_embed[aoff:aoff + n]
+                aoff += n
+
+        t_vals = torch.tensor(unique_t, dtype=torch.float32, device=device)
+        if self.use_adaln_curves:
+            # adaln projections consume interpolated coordinates of the time-embedding curve
+            table = comfy.model_management.cast_to(self.adaln_t_table, device=device)
+            pos = t_vals.clamp(0.0, 1.0) * (table.shape[0] - 1)     # t in [0,1] -> fractional grid index, out-of-range t clamps to the curve ends
+            i0 = pos.floor().long().clamp(max=table.shape[0] - 2)   # lower grid row, max-clamp keeps t=1.0 on the last interval instead of reading past the table
+            t_emb = torch.lerp(table[i0], table[i0 + 1], (pos - i0).unsqueeze(1))  # blend the two rows by the fractional part
+        else:
+            t_emb = self.time_embedder(t_vals).to(dtype)
+
+        # rotation table computed once per forward, consumed by the kitchen split-half rope
+        rope_freqs = rope_rotation_table(self.rope_freqs(layout.position_ids, device), dtype)
+
+        # blocks
+        # blocks (TE-Speed-MiniMaxH3-OSS hook)
+        patches_replace = transformer_options.get("patches_replace", {})
+        blocks_replace = patches_replace.get("dit", {})
+        cache_ranges = [(a, b) for a, b, kind in layout.segments if kind in ("audio", "video")]
+        if ("block_loop", 0) in blocks_replace:
+            def block_loop_wrap(args):
+                return {"img": self._run_blocks(args["img"], args["t_emb"], args["mod_segments"], args["rope_freqs"],
+                                                args["transformer_options"], args.get("start", 0), args.get("end"))}
+            h = blocks_replace[("block_loop", 0)](
+                {"img": h, "t_emb": t_emb, "mod_segments": mod_segments, "rope_freqs": rope_freqs,
+                 "transformer_options": transformer_options, "cache_ranges": cache_ranges, "block_count": len(self.blocks)},
+                {"original_block": block_loop_wrap})["img"]
+        else:
+            h = self._run_blocks(h, t_emb, mod_segments, rope_freqs, transformer_options)
+
+        # target streams are single contiguous segments (audio then video, last two)
+        video_seg = next((a, b, t_row[seg_t["video"]]) for a, b, k in layout.segments if k == "video")
+        audio_seg = next((a, b, t_row[seg_t["audio"]]) for a, b, k in layout.segments if k == "audio")
+        v, a = self.final_layer(h, t_emb, video_seg, audio_seg)
+
+        video_out = unpatchify_video(v, latent_t, lat_h // 2, lat_w // 2, self.latents_dim, self.patch_size)
+        video_out = video_out[:, :, :orig_t, :orig_h, :orig_w]
+        audio_out = unpack_audio(a)
+
+        # The sampler integrates the flat ODE dX/dsigma_v = (X - denoised)/sigma_v.
+        # Scaling the audio velocity by d(sigma_a)/d(sigma_v) makes that ODE equal
+        # to the audio stream's true ODE on its own shifted schedule.
+        slope_a = time_shift_slope(sigma_v, shift_v, shift_a).to(audio_out.dtype)
+        return [-video_out.to(video_x.dtype), (-slope_a) * audio_out.to(audio_x.dtype)]


### PR DESCRIPTION
## Summary

- bundle complete V100-accelerated MiniMax H3 source snapshots for both origin and TE-Speed layouts
- let the TE installer promote a supported clean origin file to the verified TE hook layout before applying the V100 patch
- make TE restore operate directly and restore the exact pre-install origin or TE source
- customize the Windows launchers for the requested ComfyUI installation path
- update English/Chinese documentation, provenance notes, and manifest hashes

## Why

The TE installer previously required an already TE-hooked `model.py`, so a clean official origin file stopped with a wrong-variant error. The dedicated TE restore BAT also depended on another BAT being present in the same extracted directory. Developers additionally had no complete patched source snapshots to inspect or port into custom ComfyUI builds.

## Impact

Users can run the TE installer on the supported clean origin source and receive the verified TE + V100 result in one guarded transaction. The bundled origin and TE `model.py` files can also be used as version-matched drop-ins or as reference implementations for manual ports.

## Validation

- manifest byte counts and SHA-256 values pass for all 14 packaged files
- Python AST parsing passes for the installer core, entry points, and both bundled model sources
- bundled source detection reports `origin/patched` and `te/patched`
- source SHA-256 values match installer outputs:
  - origin: `ff86e416f7fb25d9cb68ceda6fb3e63f95e919db51c019a5a570171bbcd28b78`
  - TE: `24c3a26708bd0d67f31013e483bd92cdf8d890ff10168c940e1e3532080e3f1c`
- repeated TE installation and restoration are idempotent
- TE restoration reproduces the original origin SHA-256 exactly
- staged diff passes `git diff --cached --check`
