### PR TITLE
Release v0.1.3 L3 memory profile

### DIFF
--- a/MANIFEST.json
+++ b/MANIFEST.json
@@ -1,105 +1,110 @@
 {
   "package": "minimax-h3-v100-patch",
-  "version": "0.1.2",
-  "default_delivery": "ComfyUI Custom Node runtime extension",
-  "profile": "FP32 base; FP16 resident QKV and text/video attention; FP32 audio attention, Q/K norm, RoPE, output projection, MLP, AdaLN and residual",
-  "compatibility": "ComfyUI 0.31.1 MiniMax H3 with the updated audio carry/sampler path",
-  "generated_date": "2026-08-11",
-  "runtime_status": "user-reported V100 runtime success on ComfyUI 0.31.1",
+  "version": "0.1.3",
+  "profile_id": "minimax-h3-v100-v013-native-fp16-branches",
+  "default_delivery": "standalone ComfyUI Custom Node runtime extension",
+  "profile": "native FP16 storage and attention/MLP branches; FP32 residual, audio recomputation, modulation, Token Refiner and final heads",
+  "compatibility": "user-reported V100 runtime success on ComfyUI 0.33.2",
+  "generated_date": "2026-08-18",
+  "runtime_status": "successful L3 V100 run with reduced resident VRAM and unchanged inference performance",
   "known_clean_origin_sha256": "1c9828ec3d38ac01398e45b1edf8d7db38fcc8148c5eb3ba8fb92b762147d0ce",
   "files": {
     ".gitignore": {
-      "bytes": 55,
-      "sha256": "c5670b4056c266e4118753354ae8e60c9f7021990901fdd0a5486c1ba0023f07"
+      "bytes": 60,
+      "sha256": "baa446a8c82fb3e01c62f3b415d0b82440606e27ed8e5286b04773a49db1a923"
     },
     "__init__.py": {
-      "bytes": 555,
-      "sha256": "a355ee8d6f945664389d25176a1ce955b32dbb5c24a0fc6d86b54a4d77ce016d"
+      "bytes": 418,
+      "sha256": "bc63357ca68525055f744a09a5e432c936643ef8d7df20bd8436e4fd4f22e472"
     },
     "LICENSE": {
       "bytes": 35149,
       "sha256": "3972dc9744f6499f0f9b2dbf76696f2ae7ad8af9b23dde66d6af86c9dfb36986"
     },
     "NOTICE.md": {
-      "bytes": 3262,
-      "sha256": "d89b37041b8e800569e55060fd8ccc8e311a6558187b1c173dddc8faaeb3673a"
+      "bytes": 3763,
+      "sha256": "f3aafb311147b9267254d2bd0e490d32dc2fff8dfc1054f1d1c96694a1fbfd30"
     },
     "README.md": {
-      "bytes": 7975,
-      "sha256": "c1f68af96254f4bf9b6782c452e5aaeaf147913b26d29512a95f5a0a365c36e9"
+      "bytes": 8586,
+      "sha256": "0ba0ab7116ad1e233b61e56a7b8091e156ca31d7055d23bf063f1ab62dc9a272"
     },
     "README_zh-CN.md": {
-      "bytes": 7762,
-      "sha256": "bc0897dfebf84f8ba512b5d7220fd69993fe6c43b23e463da355b8dc38fd670f"
+      "bytes": 8285,
+      "sha256": "01aca564e806f3ae4ed37b90ddc8e74eabb0db58f5e5e14bbe1d55d782c4f7c3"
     },
     "runtime_patch.py": {
-      "bytes": 16754,
-      "sha256": "29f66b811240459a78594a04ce1bd8843c0a79000c04f232b270fbc39cc06712"
+      "bytes": 23671,
+      "sha256": "217f7db113b1d33ab134ff8d75a9081bf421be50202f9db008a03d3ae41641d0"
     },
     "tests/test_runtime_patch.py": {
-      "bytes": 9898,
-      "sha256": "7fe7ae7b3157a1141817740cf366a2969884d91ea947c7132e3850b41e6937f2"
+      "bytes": 23093,
+      "sha256": "f83a9d45972278c1ca6b04cc8b1b54af5a837a9d3950a15d1c1a896ddb8c7b3d"
     },
     "legacy_patcher/_patch_core.py": {
-      "bytes": 30308,
-      "sha256": "4ba0816adae08313e148487b48624c8c3a5f10b95e51d8777c395f89b6aa1954"
+      "bytes": 31005,
+      "sha256": "90d9dd86a8f57f61e9fe61ef247196619a1e1b6dca68055da49729ebdf9c3330"
     },
     "legacy_patcher/LICENSE": {
-      "bytes": 35149,
-      "sha256": "3972dc9744f6499f0f9b2dbf76696f2ae7ad8af9b23dde66d6af86c9dfb36986"
+      "bytes": 35823,
+      "sha256": "230184f60bae2feaf244f10a8bac053c8ff33a183bcc365b4d8b876d2b7f4809"
     },
     "legacy_patcher/MANIFEST.json": {
-      "bytes": 2670,
-      "sha256": "2ab3f70b8ded4c8b50a1c77ab519e7db30d55003bfc4a1d331bd1c88a6e98e1f"
+      "bytes": 2738,
+      "sha256": "6138d06482654b95b4cdd1fee45da6037dfa31bf3523c579dd0174a839bd104e"
     },
     "legacy_patcher/NOTICE.md": {
-      "bytes": 3570,
-      "sha256": "38538dfef1da0d7f3494a27a87686b6c30855bfdc131460857ad9c3f504cb27e"
+      "bytes": 3633,
+      "sha256": "8639b89d16248ed0d925a5ac96d01cd809034c0bd2e6e4b438566fea54f8aaa3"
     },
     "legacy_patcher/patch_h3_origin_v100.bat": {
-      "bytes": 1323,
-      "sha256": "d808ba779622b20e2752895ce7e17ab56ca8d134ac0e6fe788f3abbc2111c8c3"
+      "bytes": 1370,
+      "sha256": "6b4fb48117b7d29ae7bb4ae5ddbd0d4236fc79327c18a41b7ff62de8e3e3ecd3"
     },
     "legacy_patcher/patch_h3_origin_v100.py": {
-      "bytes": 226,
-      "sha256": "70d676dde67ae85154a9a2f7988d1f0f10c7e8ad4099061444b81ba42b7c4762"
+      "bytes": 236,
+      "sha256": "cd5a62f4151cfac57eab149d216d830f188292a6ba31c39a72f4fc3d5d345483"
     },
     "legacy_patcher/patch_te_v100.bat": {
-      "bytes": 1509,
-      "sha256": "7fa845c374c5ed832543f70a6bb1501035e56327bbc7a7dc821a30c43ab17382"
+      "bytes": 1559,
+      "sha256": "443c315b4d2020ba6c4aaea2a9d09d6a0e2a6dbeefe9bbcf838effa806316501"
     },
     "legacy_patcher/patch_te_v100.py": {
-      "bytes": 247,
-      "sha256": "1cf4a0d4b4bad5c402bffd21b224c7d44b02aa1d3dc08c57ed9bb3c93797a784"
+      "bytes": 257,
+      "sha256": "2e7063f412cadec3d9eab4a363d3b779a23314f76c17af260d596cf5c57b0de0"
     },
     "legacy_patcher/restore_h3_origin_v100.bat": {
-      "bytes": 278,
-      "sha256": "3d77a96bc3122f0dddcf2ff53e8fa01d4be12a84df79f09fe17eaba3cb80d0a3"
+      "bytes": 291,
+      "sha256": "9efbb28523f8f2e21a49b5e068d4d79dbcade4f70b292d94dbbc7c966d6869ac"
     },
     "legacy_patcher/restore_te_v100.bat": {
-      "bytes": 1578,
-      "sha256": "97af485d1f62350e7b7bc71b60c028c91766a506d0cdad36ec389c4e1450b8a2"
+      "bytes": 1634,
+      "sha256": "920f248cd6776464bdaf6349fb4aa5049371eb90884008301d999d69c2ed0fd9"
     },
     "legacy_patcher/sources/origin_v100/model.py": {
-      "bytes": 36622,
-      "sha256": "0bfd99dfc298cf33a44d70de0f4e1521120d665fa2d15efbd24a0963d350937e"
+      "bytes": 37337,
+      "sha256": "a65a605f2b6476db1c4e25f42ccfd660620f53b72ddc1bc494a5ac14a2bd01f5"
     },
     "legacy_patcher/sources/te_v100/model.py": {
-      "bytes": 37871,
-      "sha256": "0164f795ae24a72f18a35846227148bde16b01dca70d63f3e40bf9fcf70cdf8e"
+      "bytes": 38605,
+      "sha256": "c96ede0c7c3f355deae37f445284d51dc6b2442529c9a48cadbf991449bd8637"
     }
   },
   "validation": {
     "python_ast": "passed",
-    "simulated_loader_tests": "passed (6 tests)",
-    "runtime_version_reporting": "passed (0.1.2)",
+    "simulated_loader_tests": "passed (14 tests)",
+    "runtime_version_reporting": "passed (0.1.3)",
+    "v100_only": "passed",
+    "native_fp16_registration": "passed",
     "main_dit_only": "passed",
     "token_refiner_excluded": "passed",
-    "audio_range_context_and_reset": "passed",
-    "invalid_audio_range_fail_closed": "passed",
+    "fp32_audio_and_final_safety": "passed",
+    "l3_compute_kernel_hashes": "passed",
     "early_and_late_runtime_conflicts": "passed",
+    "lazy_weight_mutation_absent": "passed",
+    "allocator_debug_telemetry_absent": "passed",
     "source_write_api_absent": "passed",
-    "legacy_origin_patch_restore_roundtrip": "passed",
-    "legacy_origin_to_te_patch_restore_roundtrip": "passed"
+    "legacy_origin_patch_restore_roundtrip": "carried forward unchanged from v0.1.2",
+    "legacy_origin_to_te_patch_restore_roundtrip": "carried forward unchanged from v0.1.2"
   }
 }

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -2,46 +2,55 @@
 
 ## Release
 
-- Package version: `0.1.2`
-- Default delivery: ComfyUI Custom Node loaded at runtime
-- Supported target used for structural and runtime validation: ComfyUI `0.31.1` MiniMax H3 with the updated audio carry/sampler path
-- Supported clean origin `model.py` SHA-256: `1c9828ec3d38ac01398e45b1edf8d7db38fcc8148c5eb3ba8fb92b762147d0ce`
-- Relevant upstream audio fix: ComfyUI commit `93cb5edb`
+- Package version: `0.1.3`
+- Default delivery: standalone ComfyUI Custom Node loaded at runtime
+- Target GPU: NVIDIA Tesla V100 / CUDA compute capability 7.0
+- Current reported compatibility: ComfyUI `0.33.2`
+- Profile: successful L3 native-FP16 storage/branch profile with FP32 safety islands
 
 ## Precision-profile provenance
 
-Version 0.1.2 preserves the existing audio-safe V100 profile:
+Version 0.1.3 promotes the successful, debug-free L3 profile to the formal release:
 
-- FP16 resident QKV weights, QKV projection, and text/video attention in the main DiT blocks.
-- FP32 target/reference-audio attention, Q/K RMSNorm, RoPE, output projection, MLP, AdaLN, residual accumulation, and final heads.
-- Source behavior for the two token-refiner blocks.
+- Native FP16 weights through ComfyUI loading, prefetch and offload.
+- FP16 QKV, Q/K RMSNorm, RoPE and text/video attention in the main DiT blocks.
+- FP32 target/reference-audio attention recomputation.
+- Power-of-two scaling around FP16 attention output projection and MLP `fc2`.
+- FP32 main residual, Block Norm, AdaLN/modulation, condition input, Token Refiner, SwiGLU intermediates, final AdaLN and video/audio heads.
 
-The Custom Node changes only how this established profile is delivered. Import-time wrappers replace persistent edits to `comfy/ldm/minimax/model.py`.
+Full-FP16 final heads remain excluded. The implementation does not mutate `weight.data`, retain a complete FP32 weight mirror across blocks, or convert full weights inside `forward`.
 
 ## Runtime implementation
 
-- `MiniMaxH3Model.__init__` enables the profile only on the main DiT blocks.
-- `MiniMaxH3Model._forward` and `PackedLayout.__init__` expose target/reference-audio row ranges through task-local runtime context.
-- `Attention.forward` performs the FP16 QKV/text-video work and recomputes audio query rows with FP32 attention.
-- `DiTBlock.forward`, `MLP.forward`, AdaLN, residual code, output projections, token refiners, and final heads are not replaced.
-- Method-ownership and structural checks refuse incompatible or stacked H3 runtime patches.
-- Missing/invalid audio row metadata fails closed to full FP32 attention for that call.
+- Registers FP16 as a supported MiniMax H3 inference dtype before model construction so ComfyUI owns the FP16 weight lifecycle.
+- Enables the profile only on native-FP16 main DiT blocks; the Token Refiner remains outside the accelerated block profile.
+- Preserves target/reference-audio row ranges through task-local runtime context.
+- Uses `/64 → FP16 out_proj → FP32 ×64` and `/256 → FP16 fc2 → FP32 ×256`.
+- Forces `condition_proj` input and both final output heads through FP32 safety paths.
+- Refuses unsupported GPUs, unfamiliar ComfyUI H3 structures, source patches, pre-existing FP16 dtype providers and late runtime conflicts.
+- Contains no per-forward allocator telemetry, OOM diagnostic interception, cache clearing, CUDA synchronization or peak-counter reset.
+- Does not modify any ComfyUI source file.
 
-## Validation completed on 2026-08-11
+## Validation completed on 2026-08-18
 
-- The user reported successful ComfyUI 0.31.1 V100 operation with normal output after testing the new Custom Node delivery.
-- Python AST parsing passed for the package, runtime implementation, and tests.
-- Dependency-free simulated-loader tests cover installation, version reporting, idempotence, main-block-only activation, token-refiner exclusion, audio-range capture/reset, invalid-range fail-closed behavior, early/late conflict refusal, and absence of source-file write APIs.
-- The supported clean origin text was reconstructed in memory from the verified bundled output; its SHA-256 matched the expected clean hash exactly.
-- No ComfyUI source file is modified by the Custom Node.
+- The user reported that the L3 profile successfully reduced inference-period resident VRAM while keeping inference performance unchanged.
+- The user reported successful operation with ComfyUI 0.33.2.
+- Fourteen dependency-free tests cover version reporting, V100 restriction, native-FP16 registration, main-block/Token-Refiner isolation, dtype flow, FP32 audio/final safety, power-of-two scaling, idempotence, early/late conflict refusal, no lazy weight mutation, no source writes and no allocator debug telemetry.
+- The promoted release compute-kernel AST hashes match the successful L3 profile.
+
+Target-GPU results remain workload-specific; users should hold model, seed, prompt, sampler, steps, dimensions, attention backend, offload mode and power limit constant when comparing releases.
+
+## Compatibility boundary
+
+This is the standalone v0.1.3 runtime profile. It must not be stacked with TE-Speed or another H3 runtime/dtype patch. A separately reviewed adapter is required for combined execution.
 
 ## Legacy patcher
 
-The earlier guarded source patchers, restore scripts, source snapshots, their original manifest, and their detailed provenance notice are retained under `legacy_patcher/`. They remain available for recovery, development, and users who explicitly need source-modifying installation, but the Custom Node is the recommended path for normal use.
+The earlier guarded source patchers, restore scripts, source snapshots, their original manifest and detailed provenance notice remain under `legacy_patcher/`. They are retained for recovery and development and are not the recommended v0.1.3 installation path.
 
 ## Acknowledgement
 
-Thanks to [Amduraznak/minimax-h3-fp16-fix](https://github.com/Amduraznak/minimax-h3-fp16-fix) for demonstrating a practical ComfyUI Custom Node delivery pattern for MiniMax H3 acceleration. That project inspired the move away from persistent source edits. Version 0.1.2 retains this project's independently tested FP32-base precision boundary; this acknowledgement concerns the deployment approach.
+Thanks to [Amduraznak/minimax-h3-fp16-fix](https://github.com/Amduraznak/minimax-h3-fp16-fix) for demonstrating a practical ComfyUI Custom Node delivery pattern and the native-FP16/FP32-residual design with power-of-two projection scaling. This is a community extension, not an official MiniMax, ComfyUI, NVIDIA, PyTorch, TE-Speed or acknowledged-project release.
 
 ## Licensing
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# MiniMax H3 V100 mixed precision — Custom Node v0.1.2
+# MiniMax H3 V100 mixed precision — Custom Node v0.1.3
 
 English | [简体中文](README_zh-CN.md)
 
-V**0.1.2** also works with ComfyUI 0.32.0
+**Version 0.1.3 reduces resident VRAM usage while keeping inference performance unchanged. It has been successfully run with ComfyUI 0.33.2.**
 
-Version **0.1.2** delivers the tested MiniMax H3 V100 mixed-precision profile as a ComfyUI Custom Node. This is now the recommended installation method: it does not rewrite `comfy/ldm/minimax/model.py`, does not require a modified launch command, and can be removed by deleting one folder and restarting ComfyUI.
+Version **0.1.3** promotes the successful L3 mixed-precision profile to the official Custom Node release. Model weights now remain FP16 through ComfyUI loading, prefetch and offload, while numerically sensitive residual, audio and output paths retain FP32 safety islands.
 
-The Custom Node mode supports the updated MiniMax H3 audio carry/sampler structure in **ComfyUI 0.31.1**. The user has reported successful V100 operation after testing this runtime build.
+The Custom Node does not rewrite `comfy/ldm/minimax/model.py`, does not require a modified launch command, and can be removed by deleting one folder and restarting ComfyUI. Earlier v0.1.2 builds were also reported working on ComfyUI 0.31.1 and 0.32.0.
 
 The previous source-modifying installers are still available under [`legacy_patcher/`](legacy_patcher/) for recovery, development, and users who explicitly need them.
 
@@ -43,8 +43,8 @@ The runtime extension intentionally refuses to stack on top of the old source pa
 5. Confirm that the startup log contains:
 
    ```text
-   [MiniMax H3 V100] v0.1.2 runtime profile installed: FP32 base + FP16 QKV/text-video attention + FP32 audio attention
-   [MiniMax H3 V100] no --fp16-unet flag is required; source files remain untouched
+   [MiniMax H3 V100] v0.1.3 runtime profile installed: v0.1.3: native FP16 storage/branches + FP32 safety islands
+   [MiniMax H3 V100] registered native FP16 H3 loading for CUDA capability 7.0 (Volta/V100); no --fp16-unet flag is required
    ```
 
 The first H3 model load also reports how many main DiT blocks were enabled. The extension adds no workflow node; existing MiniMax H3 workflows continue to be used normally.
@@ -54,15 +54,16 @@ The first H3 model load also reports how many main DiT blocks were enabled. The 
 - Update: stop ComfyUI, replace this repository folder with the new version, and restart.
 - Uninstall: delete this repository folder from `custom_nodes` and restart. No ComfyUI source backup needs to be restored when only the Custom Node mode was used.
 
-## Precision split
+## v0.1.3 memory and precision split
 
-The 50 main DiT blocks use the established FP32-base profile:
+- Native FP16 model storage through ComfyUI loading, prefetch and offload.
+- FP16 QKV, Q/K RMSNorm, RoPE and text/video attention in the 50 main DiT blocks.
+- FP32 target/reference-audio attention recomputation.
+- Scaled attention output projection: `/64 → FP16 out_proj → FP32 ×64`.
+- FP16 MLP `fc1`, FP32 SwiGLU, and scaled `fc2`: `/256 → FP16 fc2 → FP32 ×256`.
+- FP32 main residual stream, Block Norm, AdaLN/modulation, condition input, Token Refiner, final AdaLN and video/audio output heads.
 
-- FP16: resident fused-QKV weights, fused QKV projection, and text/video attention queries.
-- FP32: target/reference-audio attention queries, Q/K RMSNorm, RoPE, attention output projection, MLP, AdaLN, residual accumulation, and final output heads.
-- Source compute path: the two token-refiner blocks.
-
-Audio FP32 attention receives Q/K/V values produced by the FP16 QKV projection, while the audio attention operation itself is FP32. The profile activates only for CUDA FP32 main-block input during inference. CPU, BF16, global-FP16, and training calls delegate to the source implementation.
+Full-FP16 final heads remain deliberately excluded. Version 0.1.3 obtains its memory reduction from native FP16 residency rather than converting full weights inside `forward`; it does not retain a full FP32 weight mirror across blocks.
 
 ## Runtime safety
 
@@ -71,10 +72,13 @@ Audio FP32 attention receives Q/K/V values produced by the FP16 QKV projection, 
 - Rechecks for extensions loaded later and keeps new model instances unmodified if a conflict appears.
 - Installs idempotently.
 - Missing or invalid audio row metadata fails closed to full FP32 attention for that call.
-- QKV weights outside FP32/FP16 are not force-converted; that block returns to the source path.
+- Refuses a second extension or source patch that already exposes a conflicting H3 FP16 path.
+- Does not mutate `weight.data`, cache complete FP32 weight mirrors, or convert full weights inside `forward`.
 - Does not open, replace, rename, or write any ComfyUI source file.
 
-This runtime build targets the ComfyUI 0.31.1 H3 structure containing the updated audio carry/sampler path and `PackedLayout.segments`. A future ComfyUI internal refactor may cause an intentional automatic disable instead of an unsafe partial patch.
+This runtime build has been run successfully with the ComfyUI 0.33.2 H3 structure. A future ComfyUI internal refactor may cause an intentional automatic disable instead of an unsafe partial patch.
+
+This is the standalone v0.1.3 runtime profile. Do not stack it with TE-Speed or another H3 runtime/dtype patch; a separately reviewed adapter is required for combined execution.
 
 ## Performance evidence
 
@@ -85,7 +89,7 @@ Earlier V100 test case: 0.2 MP, 5 s, 24 fps. Environment: Windows 10, NVIDIA Tes
 | TE-Speed baseline | 317 s | — | Passed |
 | **MiniMax H3 V100 mixed-precision profile** | **206 s** | **35.0% faster / 1.54x** | **Passed** |
 
-These figures demonstrate the earlier core precision profile and are not a universal timing guarantee for every ComfyUI workflow. In the later audio-safe build, resident FP16 QKV weights provided an additional reported improvement of approximately **5%–10%** over recasting those weights during inference. Actual results depend on workload, backend, offload behavior, power limit, and build.
+These figures document the earlier core acceleration profile and are not a universal timing guarantee for every ComfyUI workflow. The v0.1.3 L3 validation reduced resident VRAM without changing the measured inference performance of its comparison build. Actual results depend on workload, backend, offload behavior, power limit, and software build.
 
 For the first A/B test, keep the seed, prompt, model, sampler, steps, resolution, frame count, and attention backend identical. Disable unrelated TeaCache, SageAttention, compilation, global FP16, and FP16-accumulation changes; discard one warm-up run and record at least three measured runs. Stop at the first black frame, NaN, audio defect, or error.
 
@@ -122,7 +126,7 @@ Development source snapshots:
 - [`legacy_patcher/sources/origin_v100/model.py`](legacy_patcher/sources/origin_v100/model.py): official/origin loop plus the audio-safe V100 profile.
 - [`legacy_patcher/sources/te_v100/model.py`](legacy_patcher/sources/te_v100/model.py): TE-Speed block-loop hooks plus the same profile.
 
-The supported clean origin source is derived from the ComfyUI implementation containing audio fix [`93cb5edb`](https://github.com/Comfy-Org/ComfyUI/commit/93cb5edb) and has SHA-256 `1c9828ec3d38ac01398e45b1edf8d7db38fcc8148c5eb3ba8fb92b762147d0ce`. See [`legacy_patcher/NOTICE.md`](legacy_patcher/NOTICE.md) for the original patcher evidence and [`NOTICE.md`](NOTICE.md) for the v0.1.2 runtime boundary.
+The supported clean origin source is derived from the ComfyUI implementation containing audio fix [`93cb5edb`](https://github.com/Comfy-Org/ComfyUI/commit/93cb5edb) and has SHA-256 `1c9828ec3d38ac01398e45b1edf8d7db38fcc8148c5eb3ba8fb92b762147d0ce`. See [`legacy_patcher/NOTICE.md`](legacy_patcher/NOTICE.md) for the original patcher evidence and [`NOTICE.md`](NOTICE.md) for the current runtime boundary.
 
 ## Acknowledgements
 

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -1,12 +1,12 @@
-# MiniMax H3 V100 混合精度 Custom Node v0.1.2
+# MiniMax H3 V100 混合精度 Custom Node v0.1.3
 
 [English](README.md) | 简体中文
 
-V**0.1.2**在**ComfyUI 0.32.0**下也可以运行
+**v0.1.3 新版优化了推理期间的常驻显存开销，同时保持推理性能不变；目前已在 ComfyUI 0.33.2 上成功运行。**
 
-从 **0.1.2** 开始，本项目将经过 V100 实测的 MiniMax H3 混合精度方案改为 ComfyUI Custom Node 运行时加载。这是现在推荐的安装方式：不再改写 `comfy/ldm/minimax/model.py`，不需要修改启动命令，删除一个文件夹并重启即可卸载。
+**v0.1.3** 将已经成功的 L3 混合精度方案提升为正式 Custom Node 版本。模型权重在 ComfyUI 加载、预取和卸载期间保持 FP16 常驻，同时为数值敏感的残差、音频和最终输出路径保留 FP32 安全岛。
 
-新版 Custom Node 已适配 **ComfyUI 0.31.1** 更新后的 MiniMax H3 audio carry/sampler 结构；用户已在 V100 上完成实际运行测试并确认工作正常。
+Custom Node 不再改写 `comfy/ldm/minimax/model.py`，不需要修改启动命令，删除一个文件夹并重启即可卸载。此前的 v0.1.2 也曾在 ComfyUI 0.31.1 和 0.32.0 上成功运行。
 
 此前会修改源码的安装器仍完整保存在 [`legacy_patcher/`](legacy_patcher/) 中，用于恢复、开发，以及确实需要源码补丁的场景。
 
@@ -43,8 +43,8 @@ legacy_patcher\restore_h3_origin_v100.bat "D:\ComfyUI\comfy\ldm\minimax\model.py
 5. 在启动日志中确认出现：
 
    ```text
-   [MiniMax H3 V100] v0.1.2 runtime profile installed: FP32 base + FP16 QKV/text-video attention + FP32 audio attention
-   [MiniMax H3 V100] no --fp16-unet flag is required; source files remain untouched
+   [MiniMax H3 V100] v0.1.3 runtime profile installed: v0.1.3: native FP16 storage/branches + FP32 safety islands
+   [MiniMax H3 V100] registered native FP16 H3 loading for CUDA capability 7.0 (Volta/V100); no --fp16-unet flag is required
    ```
 
 第一次加载 H3 模型时，日志还会显示已启用的主 DiT Block 数量。本扩展不会在工作流界面增加节点，现有 MiniMax H3 工作流照常使用。
@@ -54,15 +54,16 @@ legacy_patcher\restore_h3_origin_v100.bat "D:\ComfyUI\comfy\ldm\minimax\model.py
 - 更新：关闭 ComfyUI，用新版本替换本仓库文件夹，然后重启。
 - 卸载：从 `custom_nodes` 删除本仓库文件夹并重启。如果只使用过 Custom Node 模式，不需要恢复任何 ComfyUI 源码备份。
 
-## 精度分配
+## v0.1.3 显存与精度分配
 
-50 个主要 DiT Block 继续采用已经验证的“FP32 海洋 + FP16 热点岛屿”方案：
+- ComfyUI 加载、预取和卸载期间使用原生 FP16 模型存储。
+- 50 个主 DiT Block 的 QKV、Q/K RMSNorm、RoPE 及文本/视频 Attention 使用 FP16。
+- 目标/参考音频 Attention 使用 FP32 重算。
+- Attention 输出投影使用 `/64 → FP16 out_proj → FP32 ×64`。
+- MLP 使用 FP16 `fc1`、FP32 SwiGLU，以及 `/256 → FP16 fc2 → FP32 ×256`。
+- 主残差、Block Norm、AdaLN/调制、condition 输入、Token Refiner、最终 AdaLN 和视频/音频输出头保持 FP32。
 
-- FP16：常驻的融合 QKV 权重、融合 QKV 投影，以及文本/视频查询的 Attention。
-- FP32：目标/参考音频查询的 Attention、Q/K RMSNorm、RoPE、Attention 输出投影、MLP、AdaLN、残差累加和最终输出头。
-- 保持源码计算路径：两个 Token Refiner Block。
-
-音频 FP32 Attention 使用的 Q/K/V 数值来自 FP16 QKV 投影，但音频 Attention 运算本身使用 FP32。本方案只在推理期间、主 Block 输入为 CUDA FP32 时启用；CPU、BF16、全局 FP16 和训练路径均调用源码原始实现。
+仍然不启用全 FP16 final heads。v0.1.3 通过原生 FP16 常驻降低显存，而不是在 `forward` 内反复转换完整权重，也不会跨 Block 保留完整 FP32 权重镜像。
 
 ## 运行时安全机制
 
@@ -71,10 +72,13 @@ legacy_patcher\restore_h3_origin_v100.bat "D:\ComfyUI\comfy\ldm\minimax\model.py
 - 如果其他扩展在本项目之后加载，也会再次检查，并让新模型实例保持未修改状态。
 - 重复加载具有幂等性。
 - 音频行信息缺失或无效时，该次调用安全回退到完整 FP32 Attention。
-- QKV 权重不是 FP32/FP16 时不会强制转换，对应 Block 返回源码路径。
+- 检测到其他扩展或源码补丁已经暴露冲突的 H3 FP16 路径时拒绝叠加。
+- 不修改 `weight.data`，不缓存完整 FP32 权重镜像，也不在 `forward` 内转换完整权重。
 - 不会打开、替换、重命名或写入任何 ComfyUI 源码文件。
 
-当前版本面向包含新版 audio carry/sampler 和 `PackedLayout.segments` 的 ComfyUI 0.31.1 H3 结构。如果未来 ComfyUI 重构内部实现，本扩展会优先自动禁用，而不是执行不完整的危险补丁。
+本版本已经在 ComfyUI 0.33.2 的 H3 结构上成功运行。如果未来 ComfyUI 重构内部实现，本扩展会优先自动禁用，而不是执行不完整的危险补丁。
+
+这是独立运行的 v0.1.3 正式版。不要与 TE-Speed 或其他 H3 runtime/dtype patch 叠加；组合运行需要单独审核的适配版本。
 
 ## 性能依据
 
@@ -85,7 +89,7 @@ legacy_patcher\restore_h3_origin_v100.bat "D:\ComfyUI\comfy\ldm\minimax\model.py
 | TE-Speed 基线 | 317 秒 | — | 成功 |
 | **MiniMax H3 V100 混合精度方案** | **206 秒** | **加速 35.0% / 1.54 倍** | **成功** |
 
-这些数字用于说明早期核心精度方案，不代表所有 ComfyUI 工作流都能获得相同耗时。在后续音频安全版本中，相比推理期间反复转换 QKV 权重，QKV 权重常驻 FP16 额外获得了约 **5%–10%** 的实测提升。实际结果取决于工作负载、Attention 后端、卸载方式、功率限制和软件构建。
+这些数字用于记录早期核心加速方案，不代表所有 ComfyUI 工作流都能获得相同耗时。v0.1.3 的 L3 验证降低了推理期间常驻显存，同时没有改变其对照版本的实测推理性能。实际结果取决于工作负载、Attention 后端、卸载方式、功率限制和软件构建。
 
 第一次 A/B 测试应固定随机种子、提示词、模型、采样器、步数、分辨率、帧数和 Attention 后端，并关闭无关的 TeaCache、SageAttention、编译、全局 FP16 和 FP16 accumulation 改动。丢弃一次预热并至少记录三次正式运行；遇到第一处黑屏、NaN、音频异常或报错时立即停止继续扩大精度边界。
 
@@ -122,7 +126,7 @@ python legacy_patcher/patch_h3_origin_v100.py /path/to/ComfyUI
 - [`legacy_patcher/sources/origin_v100/model.py`](legacy_patcher/sources/origin_v100/model.py)：官方/origin Block Loop 加音频安全 V100 方案。
 - [`legacy_patcher/sources/te_v100/model.py`](legacy_patcher/sources/te_v100/model.py)：TE-Speed Block Loop 钩子加相同精度方案。
 
-受支持的干净 origin 源码基于包含 ComfyUI audio 修复 [`93cb5edb`](https://github.com/Comfy-Org/ComfyUI/commit/93cb5edb) 的实现，其 SHA-256 为 `1c9828ec3d38ac01398e45b1edf8d7db38fcc8148c5eb3ba8fb92b762147d0ce`。旧 patcher 的验证证据见 [`legacy_patcher/NOTICE.md`](legacy_patcher/NOTICE.md)，0.1.2 运行时边界见 [`NOTICE.md`](NOTICE.md)。
+受支持的干净 origin 源码基于包含 ComfyUI audio 修复 [`93cb5edb`](https://github.com/Comfy-Org/ComfyUI/commit/93cb5edb) 的实现，其 SHA-256 为 `1c9828ec3d38ac01398e45b1edf8d7db38fcc8148c5eb3ba8fb92b762147d0ce`。旧 patcher 的验证证据见 [`legacy_patcher/NOTICE.md`](legacy_patcher/NOTICE.md)，当前运行时边界见 [`NOTICE.md`](NOTICE.md)。
 
 ## 致谢
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,13 +1,11 @@
-"""ComfyUI loader entry point for the MiniMax H3 V100 mixed-precision profile."""
+"""ComfyUI entry point for the MiniMax H3 V100 v0.1.3 profile."""
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 
 from .runtime_patch import PATCH_STATUS, install_patch
 
 
-# This extension changes H3 internals at import time and intentionally exposes no
-# workflow node. Keeping these mappings empty makes it a drop-in custom_nodes
-# extension without adding UI clutter.
+# Import-time runtime extension: existing H3 workflows need no extra UI node.
 NODE_CLASS_MAPPINGS = {}
 NODE_DISPLAY_NAME_MAPPINGS = {}
 

--- a/runtime_patch.py
+++ b/runtime_patch.py
@@ -1,13 +1,13 @@
-"""Runtime MiniMax H3 V100 mixed-precision patch for ComfyUI.
+"""MiniMax H3 V100 v0.1.3 mixed-precision profile for ComfyUI.
 
-The profile deliberately starts from ComfyUI's FP32 H3 path. Only the fused
-QKV projection and text/video attention of the main DiT blocks are moved to
-FP16. Q/K RMSNorm, RoPE, target/reference-audio attention, attention output
-projection, MLP, AdaLN, the residual stream, token refiners, and final heads
-remain on their source/FP32 paths.
+This release registers FP16 as a supported inference dtype for MiniMax H3
+before the model is instantiated. Main-block weights are therefore created,
+loaded, prefetched, and offloaded through ComfyUI's native FP16 path. The main
+DiT residual stream is promoted to FP32 while its attention/MLP branches run in
+FP16. Target/reference-audio attention and SwiGLU intermediates run in FP32;
+scaled output projections return FP32 values to the residual stream.
 
-No ComfyUI source file is modified. The patch is installed when ComfyUI imports
-this custom-node package and is removed by deleting the package and restarting.
+No ComfyUI source file is modified and no --fp16-unet flag is required.
 
 SPDX-License-Identifier: GPL-3.0-only
 """
@@ -19,32 +19,43 @@ import inspect
 from typing import Any, Iterable
 
 import torch
+from torch.nn import functional as F
 
 import comfy.ldm.minimax.model as mm
 import comfy.model_management as model_management
 import comfy.quant_ops as quant_ops
+import comfy.supported_models as supported_models
 from comfy.ldm.modules.attention import attention_pytorch, optimized_attention
 
 
-PROFILE_ID = "minimax-h3-v100-fp32-base-fp16-hotspots-audio-safe-v1"
-PROFILE_LABEL = "FP32 base + FP16 QKV/text-video attention + FP32 audio attention"
-PACKAGE_VERSION = "0.1.2"
+PROFILE_ID = "minimax-h3-v100-v013-native-fp16-branches"
+PROFILE_LABEL = "v0.1.3: native FP16 storage/branches + FP32 safety islands"
+PACKAGE_VERSION = "0.1.3"
+OUT_PROJ_SCALE = 64.0
+MLP_FC2_SCALE = 256.0
+
 _MODULE_PATCH_MARKER = "_minimax_h3_v100_custom_node_profile"
-_ATTENTION_ENABLE_FLAG = "_minimax_h3_v100_fp16_hotspots"
-_QKV_WEIGHT_FLAG = "_minimax_h3_v100_resident_fp16_qkv"
+_SUPPORTED_MODEL_PATCH_MARKER = "_minimax_h3_v100_supported_dtype_profile"
+_BLOCK_ENABLE_FLAG = "_minimax_h3_v100_v013_fp32_residual"
+_ATTENTION_ENABLE_FLAG = "_minimax_h3_v100_v013_audio_safe_attention"
+_MLP_ENABLE_FLAG = "_minimax_h3_v100_v013_scaled_mlp"
+_FINAL_ENABLE_FLAG = "_minimax_h3_v100_v013_fp32_final"
+_CONDITION_WRAPPED_FLAG = "_minimax_h3_v100_v013_fp32_condition"
 _LAYOUT_RANGES_ATTR = "_minimax_h3_v100_fp32_audio_ranges"
 _OPTIONS_RANGES_KEY = "minimax_h3_fp32_audio_ranges"
 
 _AUDIO_RANGES: contextvars.ContextVar[tuple[tuple[int, int], ...]] = contextvars.ContextVar(
-    "minimax_h3_v100_audio_ranges", default=()
+    "minimax_h3_v100_v013_audio_ranges", default=()
 )
 _CAPTURE_LAYOUT: contextvars.ContextVar[bool] = contextvars.ContextVar(
-    "minimax_h3_v100_capture_layout", default=False
+    "minimax_h3_v100_v013_capture_layout", default=False
 )
 
+_ORIGINAL_SUPPORTED_DTYPES = None
 _ORIGINAL_ATTENTION_FORWARD = None
 _ORIGINAL_BLOCK_FORWARD = None
 _ORIGINAL_MLP_FORWARD = None
+_ORIGINAL_FINAL_FORWARD = None
 _ORIGINAL_MODEL_INIT = None
 _ORIGINAL_MODEL_FORWARD = None
 _ORIGINAL_LAYOUT_INIT = None
@@ -78,16 +89,42 @@ def _source_contains(function: Any, required: Iterable[str]) -> bool:
     return all(token in source for token in required)
 
 
-def _validate_runtime_shape() -> tuple[bool, str]:
-    """Refuse unknown or already-rewritten internals before changing classes."""
+def _target_device_supported() -> tuple[bool, str]:
+    """Limit automatic native-FP16 selection to the Volta/V100 target."""
 
-    required_types = ("Attention", "DiTBlock", "MLP", "MiniMaxH3Model", "PackedLayout")
+    try:
+        if not torch.cuda.is_available():
+            return False, "CUDA is unavailable"
+        capability = tuple(torch.cuda.get_device_capability())
+    except (AssertionError, RuntimeError, TypeError) as exc:
+        return False, f"CUDA capability detection failed: {exc}"
+    if capability != (7, 0):
+        return False, f"CUDA capability {capability[0]}.{capability[1]} is not the V100 target 7.0"
+    return True, "CUDA capability 7.0 (Volta/V100)"
+
+
+def _validate_runtime_shape() -> tuple[bool, str]:
+    """Refuse unknown source structures or pre-existing runtime rewrites."""
+
+    required_types = (
+        "Attention",
+        "DiTBlock",
+        "FinalLayer",
+        "MLP",
+        "MiniMaxH3Model",
+        "PackedLayout",
+    )
     missing = [name for name in required_types if not hasattr(mm, name)]
     if missing:
         return False, "unsupported H3 module; missing " + ", ".join(missing)
+    if not hasattr(supported_models, "MiniMaxH3"):
+        return False, "unsupported ComfyUI; supported_models.MiniMaxH3 is absent"
+    if not all(hasattr(mm, name) for name in ("_mod_scale_shift", "_mod_gate")):
+        return False, "unsupported H3 module; residual modulation helpers are absent"
 
     attention_forward = mm.Attention.forward
     block_forward = mm.DiTBlock.forward
+    final_forward = mm.FinalLayer.forward
     mlp_forward = mm.MLP.forward
     model_init = mm.MiniMaxH3Model.__init__
     model_forward = getattr(mm.MiniMaxH3Model, "_forward", None)
@@ -97,25 +134,31 @@ def _validate_runtime_shape() -> tuple[bool, str]:
         return False, "unsupported H3 module; MiniMaxH3Model._forward is absent"
     if not _signature_has(attention_forward, ("self", "x", "rope_freqs", "transformer_options")):
         return False, "unsupported Attention.forward signature"
-    if not _signature_has(model_init, ("self",)):
+    if not _signature_has(block_forward, ("self", "x", "t_emb", "mod_segments", "rope_freqs")):
+        return False, "unsupported DiTBlock.forward signature"
+    if not _signature_has(mlp_forward, ("self", "x")):
+        return False, "unsupported MLP.forward signature"
+    if not _signature_has(final_forward, ("self", "x", "t_emb", "video_seg", "audio_seg")):
+        return False, "unsupported FinalLayer.forward signature"
+    if not _signature_has(model_init, ("self", "dtype", "operations")):
         return False, "unsupported MiniMaxH3Model.__init__ signature"
     if not _signature_has(model_forward, ("self", "x", "context", "transformer_options", "minimax_payload")):
         return False, "unsupported MiniMaxH3Model._forward signature"
     if not _signature_has(layout_init, ("self", "text_len", "latent_t", "audio_t")):
         return False, "unsupported PackedLayout.__init__ signature"
 
-    # Replacing a function already owned by another extension would make load
-    # order decide numerical behavior. Disable instead of silently stacking.
-    if getattr(attention_forward, "__module__", None) != mm.__name__:
-        return False, "Attention.forward is already owned by another runtime extension"
-    if getattr(block_forward, "__module__", None) != mm.__name__:
-        return False, "DiTBlock.forward is already owned by another runtime extension"
-    if getattr(mlp_forward, "__module__", None) != mm.__name__:
-        return False, "MLP.forward is already owned by another runtime extension"
-    if getattr(model_init, "__module__", None) != mm.__name__:
-        return False, "MiniMaxH3Model.__init__ is already owned by another runtime extension"
-    if getattr(model_forward, "__module__", None) != mm.__name__:
-        return False, "MiniMaxH3Model._forward is already owned by another runtime extension"
+    owned_methods = (
+        ("Attention.forward", attention_forward),
+        ("DiTBlock.forward", block_forward),
+        ("FinalLayer.forward", final_forward),
+        ("MLP.forward", mlp_forward),
+        ("MiniMaxH3Model.__init__", model_init),
+        ("MiniMaxH3Model._forward", model_forward),
+        ("PackedLayout.__init__", layout_init),
+    )
+    for label, function in owned_methods:
+        if getattr(function, "__module__", None) != mm.__name__:
+            return False, f"{label} is already owned by another runtime extension"
 
     if not _source_contains(
         attention_forward,
@@ -124,10 +167,28 @@ def _validate_runtime_shape() -> tuple[bool, str]:
         return False, "unsupported Attention.forward implementation"
     if _source_contains(attention_forward, ("fp16_qkv",)):
         return False, "a source-level MiniMax H3 V100 patch is already present"
+    if not _source_contains(
+        block_forward,
+        ("adaln_proj", "norm1", "norm2", "_mod_scale_shift", "_mod_gate"),
+    ):
+        return False, "unsupported DiTBlock.forward implementation"
+    if not _source_contains(mlp_forward, ("fc1", "fc2", "swiglu")):
+        return False, "unsupported MLP.forward implementation"
+    if not _source_contains(final_forward, ("adaln_proj", "video_out", "audio_out")):
+        return False, "unsupported FinalLayer.forward implementation"
     if not _source_contains(model_forward, ("PackedLayout", "layout.segments", "minimax_payload")):
         return False, "unsupported MiniMaxH3Model._forward implementation"
 
-    return True, "supported current MiniMax H3 structure"
+    dtype_owner = supported_models.MiniMaxH3
+    if getattr(dtype_owner, "__module__", None) != supported_models.__name__:
+        return False, "supported_models.MiniMaxH3 is already replaced by another extension"
+    current_dtypes = tuple(getattr(dtype_owner, "supported_inference_dtypes", ()))
+    if torch.float16 in current_dtypes:
+        return False, "MiniMaxH3 already exposes FP16 inference through another source or extension"
+    if torch.bfloat16 not in current_dtypes or torch.float32 not in current_dtypes:
+        return False, "unsupported MiniMaxH3 inference-dtype declaration"
+
+    return True, "supported ComfyUI 0.33.2 MiniMax H3 structure"
 
 
 def _ranges_from_layout(layout: Any) -> tuple[tuple[int, int], ...]:
@@ -136,9 +197,8 @@ def _ranges_from_layout(layout: Any) -> tuple[tuple[int, int], ...]:
     cached = getattr(layout, _LAYOUT_RANGES_ATTR, None)
     if cached is not None:
         return tuple(cached)
-    segments = getattr(layout, "segments", ())
     ranges = []
-    for segment in segments:
+    for segment in getattr(layout, "segments", ()):
         if not isinstance(segment, (tuple, list)) or len(segment) != 3:
             continue
         start, stop, kind = segment
@@ -183,7 +243,7 @@ def _patched_model_forward(
     ranges_token = _AUDIO_RANGES.set(_ranges_from_layout(layout))
     capture_token = _CAPTURE_LAYOUT.set(layout is None)
     try:
-        return _ORIGINAL_MODEL_FORWARD(
+        result = _ORIGINAL_MODEL_FORWARD(
             self,
             x,
             timestep,
@@ -195,6 +255,7 @@ def _patched_model_forward(
     finally:
         _CAPTURE_LAYOUT.reset(capture_token)
         _AUDIO_RANGES.reset(ranges_token)
+    return result
 
 
 def _attention_shape_supported(attention: Any) -> bool:
@@ -202,67 +263,92 @@ def _attention_shape_supported(attention: Any) -> bool:
     return all(hasattr(attention, name) for name in required)
 
 
+def _block_shape_supported(block: Any) -> bool:
+    return (
+        all(hasattr(block, name) for name in ("attn", "mlp", "adaln_proj", "norm1", "norm2"))
+        and _attention_shape_supported(block.attn)
+        and all(hasattr(block.mlp, name) for name in ("fc1", "fc2"))
+    )
+
+
+def _final_shape_supported(final_layer: Any) -> bool:
+    return all(
+        hasattr(final_layer, name)
+        for name in ("norm", "adaln_proj", "video_out", "audio_out")
+    )
+
+
+def _wrap_condition_projection(model: Any) -> bool:
+    projection = getattr(model, "condition_proj", None)
+    if projection is None or not hasattr(projection, "forward"):
+        return False
+    if getattr(projection, _CONDITION_WRAPPED_FLAG, False):
+        return True
+    original_forward = projection.forward
+
+    def fp32_condition_forward(value, _forward=original_forward):
+        return _forward(value.to(dtype=torch.float32))
+
+    fp32_condition_forward._minimax_h3_v100_profile = PROFILE_ID
+    projection.forward = fp32_condition_forward
+    setattr(projection, _CONDITION_WRAPPED_FLAG, True)
+    return True
+
+
 def _patched_model_init(self, *args, **kwargs):
     _ORIGINAL_MODEL_INIT(self, *args, **kwargs)
     if (
         mm.Attention.forward is not _patched_attention_forward
-        or mm.DiTBlock.forward is not _ORIGINAL_BLOCK_FORWARD
-        or mm.MLP.forward is not _ORIGINAL_MLP_FORWARD
+        or mm.DiTBlock.forward is not _patched_block_forward
+        or mm.MLP.forward is not _patched_mlp_forward
+        or mm.FinalLayer.forward is not _patched_final_forward
     ):
         _warn_once(
             "late-runtime-conflict",
-            "another H3 runtime extension loaded after this one; the FP16-hotspot profile stays disabled",
+            "another H3 runtime extension loaded after v0.1.3; new H3 instances stay unmodified",
         )
         return
-    blocks = tuple(getattr(self, "blocks", ()))
-    if not blocks:
-        _warn_once("missing-blocks", "H3 main DiT blocks were not found; this model instance stays unmodified")
+    if getattr(self, "dtype", None) != torch.float16:
+        _warn_once(
+            "model-not-native-fp16",
+            f"H3 was instantiated as {getattr(self, 'dtype', None)}, not FP16; v0.1.3 is inactive for this instance",
+        )
         return
-    if not all(hasattr(block, "attn") and _attention_shape_supported(block.attn) for block in blocks):
+
+    blocks = tuple(getattr(self, "blocks", ()))
+    if not blocks or not all(_block_shape_supported(block) for block in blocks):
         _warn_once(
             "unsupported-block",
-            "the main DiT attention structure is unfamiliar; this model instance stays unmodified",
+            "the main H3 block structure is unfamiliar; v0.1.3 is inactive for this instance",
+        )
+        return
+    final_layer = getattr(self, "final_layer", None)
+    if final_layer is None or not _final_shape_supported(final_layer):
+        _warn_once(
+            "unsupported-final-layer",
+            "the H3 FinalLayer structure is unfamiliar; v0.1.3 is inactive for this instance",
+        )
+        return
+    if not _wrap_condition_projection(self):
+        _warn_once(
+            "missing-condition-proj",
+            "condition_proj could not be wrapped for FP32 overflow safety; v0.1.3 is inactive for this instance",
         )
         return
 
     for block in blocks:
+        setattr(block, _BLOCK_ENABLE_FLAG, True)
         setattr(block.attn, _ATTENTION_ENABLE_FLAG, True)
-        setattr(block.attn, _QKV_WEIGHT_FLAG, True)
+        setattr(block.mlp, _MLP_ENABLE_FLAG, True)
+    setattr(final_layer, _FINAL_ENABLE_FLAG, True)
     _log(f"enabled {PROFILE_LABEL} on {len(blocks)} main DiT blocks")
-
-
-def _prepare_qkv_weight(attention: Any) -> bool:
-    """Convert each main-block QKV weight once; fail closed for other dtypes."""
-
-    if not getattr(attention, _QKV_WEIGHT_FLAG, False):
-        return True
-    try:
-        weight = attention.qkv_proj.weight
-        if weight.dtype == torch.float32:
-            with torch.no_grad():
-                weight.data = weight.data.to(dtype=torch.float16)
-        elif weight.dtype != torch.float16:
-            _warn_once(
-                "qkv-weight-dtype",
-                "a main QKV weight is neither FP32 nor FP16; the runtime profile is disabled for that block",
-            )
-            setattr(attention, _ATTENTION_ENABLE_FLAG, False)
-            return False
-    except (AttributeError, RuntimeError, TypeError) as exc:
-        _warn_once(
-            "qkv-weight-conversion",
-            f"resident FP16 QKV conversion failed ({exc}); the runtime profile is disabled for that block",
-        )
-        setattr(attention, _ATTENTION_ENABLE_FLAG, False)
-        return False
-    return True
 
 
 def _patched_attention_forward(self, x, rope_freqs=None, transformer_options={}):
     enabled = (
         getattr(self, _ATTENTION_ENABLE_FLAG, False)
         and getattr(getattr(x, "device", None), "type", None) == "cuda"
-        and x.dtype == torch.float32
+        and x.dtype == torch.float16
         and not model_management.in_training
     )
     if not enabled:
@@ -272,30 +358,14 @@ def _patched_attention_forward(self, x, rope_freqs=None, transformer_options={})
             rope_freqs=rope_freqs,
             transformer_options=transformer_options,
         )
-    if not _prepare_qkv_weight(self):
-        return _ORIGINAL_ATTENTION_FORWARD(
-            self,
-            x,
-            rope_freqs=rope_freqs,
-            transformer_options=transformer_options,
-        )
 
     sequence_length = x.shape[0]
-    residual_dtype = x.dtype
     options = transformer_options if hasattr(transformer_options, "get") else {}
     raw_ranges = options.get(_OPTIONS_RANGES_KEY, ()) or _AUDIO_RANGES.get()
     audio_ranges = _normalize_ranges(raw_ranges, sequence_length)
 
-    # QKV uses FP16 Tensor Cores. Q/K immediately return to FP32 for the
-    # stability-sensitive RMSNorm and RoPE operations; V stays FP16 until an
-    # FP32 attention path promotes it.
-    q, k, v = self.qkv_proj(x.to(dtype=torch.float16)).split(
-        self.heads * self.head_dim, dim=-1
-    )
-    q = q.to(dtype=torch.float32)
-    k = k.to(dtype=torch.float32)
+    q, k, v = self.qkv_proj(x).split(self.heads * self.head_dim, dim=-1)
     v = v.view(sequence_length, self.heads, self.head_dim)
-
     if rope_freqs is not None:
         q = q.view(1, sequence_length, self.heads, self.head_dim)
         k = k.view(1, sequence_length, self.heads, self.head_dim)
@@ -323,17 +393,13 @@ def _patched_attention_forward(self, x, rope_freqs=None, transformer_options={})
     v = v.transpose(0, 1).unsqueeze(0)
 
     if not audio_ranges:
-        # H3 is an audio-video model. Missing/invalid layout metadata must not
-        # silently send audio through the FP16 attention path. We keep only the
-        # already-completed FP16 QKV optimization and fail closed to full FP32
-        # attention for this call.
         _warn_once(
             "missing-audio-ranges",
-            "audio row metadata was unavailable; falling back to full FP32 attention for safety",
+            "audio row metadata was unavailable; this call falls back to full FP32 attention",
         )
         out = optimized_attention(
-            q,
-            k,
+            q.to(dtype=torch.float32),
+            k.to(dtype=torch.float32),
             v.to(dtype=torch.float32),
             self.heads,
             mask=None,
@@ -341,46 +407,139 @@ def _patched_attention_forward(self, x, rope_freqs=None, transformer_options={})
             transformer_options=options,
         )
     else:
-        # Compute the packed sequence once in FP16, then recompute only target
-        # and reference-audio query rows with FP32 attention and overwrite them.
         out = optimized_attention(
-            q.to(dtype=torch.float16),
-            k.to(dtype=torch.float16),
-            v.to(dtype=torch.float16),
+            q,
+            k,
+            v,
             self.heads,
             mask=None,
             skip_reshape=True,
             transformer_options=options,
-        ).to(dtype=residual_dtype)
+        )
+        audio_q = q.to(dtype=torch.float32)
+        audio_k = k.to(dtype=torch.float32)
         audio_v = v.to(dtype=torch.float32)
         for start, stop in audio_ranges:
-            out[:, start:stop] = attention_pytorch(
-                q[:, :, start:stop],
-                k,
+            audio_out = attention_pytorch(
+                audio_q[:, :, start:stop],
+                audio_k,
                 audio_v,
                 self.heads,
                 mask=None,
                 skip_reshape=True,
             )
+            out[:, start:stop] = audio_out.to(dtype=out.dtype)
 
-    # The output projection receives FP32 and therefore stays on the existing
-    # source/FP32 path. MLP, AdaLN and residual code are never monkey-patched.
-    return self.out_proj(out.squeeze(0))
+    projected = self.out_proj(
+        (out.squeeze(0) / OUT_PROJ_SCALE).to(dtype=torch.float16)
+    )
+    return projected.to(dtype=torch.float32).mul_(OUT_PROJ_SCALE)
+
+
+def _patched_mlp_forward(self, x):
+    enabled = (
+        getattr(self, _MLP_ENABLE_FLAG, False)
+        and getattr(getattr(x, "device", None), "type", None) == "cuda"
+        and x.dtype == torch.float16
+        and not model_management.in_training
+    )
+    if not enabled:
+        return _ORIGINAL_MLP_FORWARD(self, x)
+
+    gate, value = self.fc1(x).chunk(2, dim=-1)
+    hidden = F.silu(gate.to(dtype=torch.float32)).mul_(value.to(dtype=torch.float32))
+    projected = self.fc2(
+        (hidden / MLP_FC2_SCALE).to(dtype=torch.float16)
+    )
+    return projected.to(dtype=torch.float32).mul_(MLP_FC2_SCALE)
+
+
+def _patched_final_forward(self, x, t_emb, video_seg, audio_seg):
+    enabled = (
+        getattr(self, _FINAL_ENABLE_FLAG, False)
+        and getattr(getattr(x, "device", None), "type", None) == "cuda"
+        and not model_management.in_training
+    )
+    if not enabled:
+        return _ORIGINAL_FINAL_FORWARD(self, x, t_emb, video_seg, audio_seg)
+
+    x = x.to(dtype=torch.float32)
+    t_emb = t_emb.to(dtype=torch.float32)
+    shift, scale = self.adaln_proj(t_emb)
+    va, vb, vrow = video_seg
+    aa, ab, arow = audio_seg
+    hv = self.norm(x[va:vb]) * (1.0 + scale[vrow]) + shift[vrow]
+    ha = self.norm(x[aa:ab]) * (1.0 + scale[arow]) + shift[arow]
+    return self.video_out(hv.to(dtype=torch.float32)), self.audio_out(ha.to(dtype=torch.float32))
+
+
+def _patched_block_forward(
+    self,
+    x,
+    t_emb,
+    mod_segments,
+    rope_freqs,
+    transformer_options={},
+):
+    enabled = (
+        getattr(self, _BLOCK_ENABLE_FLAG, False)
+        and getattr(getattr(x, "device", None), "type", None) == "cuda"
+        and not model_management.in_training
+    )
+    if not enabled:
+        return _ORIGINAL_BLOCK_FORWARD(
+            self,
+            x,
+            t_emb,
+            mod_segments,
+            rope_freqs,
+            transformer_options=transformer_options,
+        )
+
+    if x.dtype != torch.float32:
+        x = x.to(dtype=torch.float32)
+    t_emb = t_emb.to(dtype=torch.float32)
+    shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = self.adaln_proj(t_emb)
+    h = mm._mod_scale_shift(self.norm1(x), shift_msa, scale_msa, mod_segments).to(
+        dtype=torch.float16
+    )
+    attention_out = self.attn(
+        h,
+        rope_freqs=rope_freqs,
+        transformer_options=transformer_options,
+    )
+    x = mm._mod_gate(
+        x,
+        gate_msa,
+        attention_out.to(dtype=torch.float32),
+        mod_segments,
+    )
+    h = mm._mod_scale_shift(self.norm2(x), shift_mlp, scale_mlp, mod_segments).to(
+        dtype=torch.float16
+    )
+    mlp_out = self.mlp(h)
+    return mm._mod_gate(
+        x,
+        gate_mlp,
+        mlp_out.to(dtype=torch.float32),
+        mod_segments,
+    )
 
 
 def install_patch() -> dict[str, Any]:
-    """Install the profile once, or return a safe disabled status."""
+    """Install native-FP16 selection and FP32 safety islands once."""
 
     existing = getattr(mm, _MODULE_PATCH_MARKER, None)
-    if existing:
-        if existing == PROFILE_ID:
+    dtype_existing = getattr(supported_models.MiniMaxH3, _SUPPORTED_MODEL_PATCH_MARKER, None)
+    if existing or dtype_existing:
+        if existing == PROFILE_ID and dtype_existing == PROFILE_ID:
             return {
                 "installed": True,
                 "profile": PROFILE_ID,
                 "version": PACKAGE_VERSION,
                 "reason": "already installed",
             }
-        reason = f"another MiniMax H3 runtime profile is already installed: {existing}"
+        reason = f"another MiniMax H3 runtime profile is installed: {existing or dtype_existing}"
         _log(f"disabled: {reason}")
         return {
             "installed": False,
@@ -389,9 +548,19 @@ def install_patch() -> dict[str, Any]:
             "reason": reason,
         }
 
+    target_ok, target_reason = _target_device_supported()
+    if not target_ok:
+        _log(f"disabled: {target_reason}; no dtype declaration or source file was changed")
+        return {
+            "installed": False,
+            "profile": PROFILE_ID,
+            "version": PACKAGE_VERSION,
+            "reason": target_reason,
+        }
+
     supported, reason = _validate_runtime_shape()
     if not supported:
-        _log(f"disabled: {reason}; no ComfyUI source file was changed")
+        _log(f"disabled: {reason}; no dtype declaration or source file was changed")
         return {
             "installed": False,
             "profile": PROFILE_ID,
@@ -399,33 +568,57 @@ def install_patch() -> dict[str, Any]:
             "reason": reason,
         }
 
+    global _ORIGINAL_SUPPORTED_DTYPES
     global _ORIGINAL_ATTENTION_FORWARD
     global _ORIGINAL_BLOCK_FORWARD
     global _ORIGINAL_MLP_FORWARD
+    global _ORIGINAL_FINAL_FORWARD
     global _ORIGINAL_MODEL_INIT
     global _ORIGINAL_MODEL_FORWARD
     global _ORIGINAL_LAYOUT_INIT
 
+    _ORIGINAL_SUPPORTED_DTYPES = tuple(supported_models.MiniMaxH3.supported_inference_dtypes)
     _ORIGINAL_ATTENTION_FORWARD = mm.Attention.forward
     _ORIGINAL_BLOCK_FORWARD = mm.DiTBlock.forward
     _ORIGINAL_MLP_FORWARD = mm.MLP.forward
+    _ORIGINAL_FINAL_FORWARD = mm.FinalLayer.forward
     _ORIGINAL_MODEL_INIT = mm.MiniMaxH3Model.__init__
     _ORIGINAL_MODEL_FORWARD = mm.MiniMaxH3Model._forward
     _ORIGINAL_LAYOUT_INIT = mm.PackedLayout.__init__
 
-    _patched_attention_forward._minimax_h3_v100_profile = PROFILE_ID
-    _patched_model_init._minimax_h3_v100_profile = PROFILE_ID
-    _patched_model_forward._minimax_h3_v100_profile = PROFILE_ID
-    _patched_layout_init._minimax_h3_v100_profile = PROFILE_ID
+    for function in (
+        _patched_attention_forward,
+        _patched_block_forward,
+        _patched_mlp_forward,
+        _patched_final_forward,
+        _patched_model_init,
+        _patched_model_forward,
+        _patched_layout_init,
+    ):
+        function._minimax_h3_v100_profile = PROFILE_ID
 
     try:
+        supported_models.MiniMaxH3.supported_inference_dtypes = [
+            torch.float16,
+            *_ORIGINAL_SUPPORTED_DTYPES,
+        ]
+        setattr(supported_models.MiniMaxH3, _SUPPORTED_MODEL_PATCH_MARKER, PROFILE_ID)
         mm.Attention.forward = _patched_attention_forward
+        mm.DiTBlock.forward = _patched_block_forward
+        mm.MLP.forward = _patched_mlp_forward
+        mm.FinalLayer.forward = _patched_final_forward
         mm.MiniMaxH3Model.__init__ = _patched_model_init
         mm.MiniMaxH3Model._forward = _patched_model_forward
         mm.PackedLayout.__init__ = _patched_layout_init
         setattr(mm, _MODULE_PATCH_MARKER, PROFILE_ID)
     except Exception:
+        supported_models.MiniMaxH3.supported_inference_dtypes = list(_ORIGINAL_SUPPORTED_DTYPES)
+        if hasattr(supported_models.MiniMaxH3, _SUPPORTED_MODEL_PATCH_MARKER):
+            delattr(supported_models.MiniMaxH3, _SUPPORTED_MODEL_PATCH_MARKER)
         mm.Attention.forward = _ORIGINAL_ATTENTION_FORWARD
+        mm.DiTBlock.forward = _ORIGINAL_BLOCK_FORWARD
+        mm.MLP.forward = _ORIGINAL_MLP_FORWARD
+        mm.FinalLayer.forward = _ORIGINAL_FINAL_FORWARD
         mm.MiniMaxH3Model.__init__ = _ORIGINAL_MODEL_INIT
         mm.MiniMaxH3Model._forward = _ORIGINAL_MODEL_FORWARD
         mm.PackedLayout.__init__ = _ORIGINAL_LAYOUT_INIT
@@ -434,7 +627,7 @@ def install_patch() -> dict[str, Any]:
         raise
 
     _log(f"v{PACKAGE_VERSION} runtime profile installed: {PROFILE_LABEL}")
-    _log("no --fp16-unet flag is required; source files remain untouched")
+    _log(f"registered native FP16 H3 loading for {target_reason}; no --fp16-unet flag is required")
     return {
         "installed": True,
         "profile": PROFILE_ID,

--- a/tests/test_runtime_patch.py
+++ b/tests/test_runtime_patch.py
@@ -1,8 +1,9 @@
-"""Dependency-free structural tests for the custom-node runtime installer."""
+"""Dependency-free structural and dtype-flow tests for v0.1.3."""
 
 from __future__ import annotations
 
-import contextlib
+import ast
+import hashlib
 import importlib.util
 from pathlib import Path
 import sys
@@ -10,36 +11,105 @@ import types
 import unittest
 
 
-class _FakeWeightData:
-    def to(self, dtype=None):
+class _FakeWeight:
+    def __init__(self, dtype="float16"):
+        self.dtype = dtype
+
+
+class _TraceTensor:
+    def __init__(self, name, dtype, trace=None, shape=(8, 16)):
+        self.name = name
+        self.dtype = dtype
+        self.trace = [] if trace is None else trace
+        self.device = types.SimpleNamespace(type="cuda")
+        self.shape = shape
+
+    def to(self, dtype=None, **kwargs):
+        self.trace.append((f"{self.name}.to", dtype))
+        return _TraceTensor(self.name, dtype, self.trace, self.shape)
+
+    def chunk(self, count, dim=-1):
+        self.trace.append((f"{self.name}.chunk", count, dim))
+        return (
+            _TraceTensor("gate", self.dtype, self.trace, self.shape),
+            _TraceTensor("value", self.dtype, self.trace, self.shape),
+        )
+
+    def __truediv__(self, scale):
+        self.trace.append((f"{self.name}/", scale, self.dtype))
+        return _TraceTensor(self.name, self.dtype, self.trace, self.shape)
+
+    def __getitem__(self, key):
+        self.trace.append((f"{self.name}[]", key, self.dtype))
+        return _TraceTensor(self.name, self.dtype, self.trace, self.shape)
+
+    def __add__(self, other):
+        other_dtype = other.dtype if isinstance(other, _TraceTensor) else None
+        self.trace.append((f"{self.name}+", other_dtype, self.dtype))
+        return _TraceTensor(self.name, self.dtype, self.trace, self.shape)
+
+    def __radd__(self, other):
+        self.trace.append((f"+{self.name}", other, self.dtype))
+        return _TraceTensor(self.name, self.dtype, self.trace, self.shape)
+
+    def __mul__(self, other):
+        other_dtype = other.dtype if isinstance(other, _TraceTensor) else None
+        self.trace.append((f"{self.name}*", other_dtype, self.dtype))
+        return _TraceTensor(self.name, self.dtype, self.trace, self.shape)
+
+    def mul_(self, other):
+        if isinstance(other, _TraceTensor):
+            self.trace.append((f"{self.name}.mul_", other.name, self.dtype, other.dtype))
+        else:
+            self.trace.append((f"{self.name}.mul_", other, self.dtype))
         return self
 
 
-class _FakeWeight:
-    dtype = "float32"
-    data = _FakeWeightData()
-
-
 class _FakeLinear:
-    weight = _FakeWeight()
+    def __init__(self, name="linear", dtype="float16"):
+        self.name = name
+        self.weight = _FakeWeight(dtype)
+
+    def __call__(self, value):
+        value.trace.append((self.name, value.dtype))
+        return _TraceTensor(f"{self.name}_out", value.dtype, value.trace, value.shape)
 
 
 class _FakeNorm:
-    weight = _FakeWeight()
-    eps = 1e-5
+    def __init__(self):
+        self.weight = _FakeWeight()
+        self.eps = 1e-5
+
+    def __call__(self, value):
+        value.trace.append(("norm", value.dtype))
+        return value
+
+
+class _FakeProjection:
+    def __init__(self):
+        self.inputs = []
+
+    def forward(self, value):
+        self.inputs.append(value.dtype)
+        return value
+
+    def __call__(self, value):
+        return self.forward(value)
 
 
 class _FakeAttention:
     def __init__(self):
         self.heads = 2
         self.head_dim = 4
-        self.qkv_proj = _FakeLinear()
+        self.qkv_proj = _FakeLinear("qkv")
         self.q_norm = _FakeNorm()
         self.k_norm = _FakeNorm()
-        self.out_proj = _FakeLinear()
+        self.out_proj = _FakeLinear("out_proj")
+
+    def __call__(self, *args, **kwargs):
+        return self.forward(*args, **kwargs)
 
     def forward(self, x, rope_freqs=None, transformer_options={}):
-        # Tokens below intentionally model the supported upstream structure.
         qkv_proj = self.qkv_proj
         q_norm = self.q_norm
         k_norm = self.k_norm
@@ -48,9 +118,65 @@ class _FakeAttention:
         return x, rope_freqs, qkv_proj, q_norm, k_norm, optimized_attention, out_proj
 
 
+class _FakeMLP:
+    def __init__(self):
+        self.fc1 = _FakeLinear("fc1")
+        self.fc2 = _FakeLinear("fc2")
+
+    def __call__(self, *args, **kwargs):
+        return self.forward(*args, **kwargs)
+
+    def forward(self, x):
+        fc1 = self.fc1
+        fc2 = self.fc2
+        swiglu = "swiglu"
+        return x, fc1, fc2, swiglu
+
+
+class _FakeAdaln:
+    def __call__(self, value):
+        return tuple(_TraceTensor(f"adaln_{index}", value.dtype, value.trace) for index in range(6))
+
+
+class _FakeFinalAdaln:
+    def __call__(self, value):
+        return (
+            _TraceTensor("final_shift", value.dtype, value.trace),
+            _TraceTensor("final_scale", value.dtype, value.trace),
+        )
+
+
+class _FakeFinalLayer:
+    def __init__(self):
+        self.norm = _FakeNorm()
+        self.adaln_proj = _FakeFinalAdaln()
+        self.video_out = _FakeLinear("video_out")
+        self.audio_out = _FakeLinear("audio_out")
+
+    def forward(self, x, t_emb, video_seg, audio_seg):
+        adaln_proj = self.adaln_proj
+        video_out = self.video_out
+        audio_out = self.audio_out
+        return x, t_emb, video_seg, audio_seg, adaln_proj, video_out, audio_out
+
+
 class _FakeBlock:
     def __init__(self):
         self.attn = _FakeAttention()
+        self.mlp = _FakeMLP()
+        self.adaln_proj = _FakeAdaln()
+        self.norm1 = _FakeNorm()
+        self.norm2 = _FakeNorm()
+
+
+class _FakeDiTBlock(_FakeBlock):
+    def forward(self, x, t_emb, mod_segments, rope_freqs, transformer_options={}):
+        adaln_proj = self.adaln_proj
+        norm1 = self.norm1
+        norm2 = self.norm2
+        _mod_scale_shift = mod_segments
+        _mod_gate = transformer_options
+        return x, t_emb, rope_freqs, adaln_proj, norm1, norm2, _mod_scale_shift, _mod_gate
 
 
 class _FakeTokenRefiner:
@@ -58,29 +184,34 @@ class _FakeTokenRefiner:
         self.blocks = [_FakeBlock(), _FakeBlock()]
 
 
-class _FakeDiTBlock(_FakeBlock):
-    def forward(self, x, t_emb, mod_segments, rope_freqs, transformer_options={}):
-        return x
-
-
-class _FakeMLP:
-    def forward(self, x):
-        return x
-
-
 class _FakePackedLayout:
-    def __init__(self, text_len, latent_t, latent_h, latent_w, audio_t, keyframes=None, refs=None, frame_count=None):
+    def __init__(
+        self,
+        text_len,
+        latent_t,
+        latent_h,
+        latent_w,
+        audio_t,
+        keyframes=None,
+        refs=None,
+        frame_count=None,
+    ):
         self.segments = [
             (0, text_len, "text"),
-            (text_len, text_len + audio_t * 2, "audio"),
-            (text_len + audio_t * 2, text_len + audio_t * 2 + latent_t, "video"),
+            (text_len, text_len + audio_t, "ref_audio"),
+            (text_len + audio_t, text_len + audio_t * 3, "audio"),
+            (text_len + audio_t * 3, text_len + audio_t * 3 + latent_t, "video"),
         ]
 
 
 class _FakeModel:
-    def __init__(self, num_layers=3, **kwargs):
+    def __init__(self, num_layers=3, dtype=None, operations=None, **kwargs):
+        self.dtype = dtype
+        self.operations = operations
+        self.condition_proj = _FakeProjection()
         self.blocks = [_FakeBlock() for _ in range(num_layers)]
         self.token_refiner = _FakeTokenRefiner()
+        self.final_layer = _FakeFinalLayer()
 
     def _forward(self, x, timestep, context, transformer_options={}, minimax_payload=None, **kwargs):
         payload = minimax_payload or {}
@@ -91,7 +222,11 @@ class _FakeModel:
         probe = transformer_options.get("probe")
         if probe is not None:
             return probe()
-        return PackedLayout, layout.segments, minimax_payload, x, timestep, context, transformer_options
+        return PackedLayout, layout.segments, minimax_payload, x, timestep, context
+
+
+class _FakeSupportedMiniMaxH3:
+    supported_inference_dtypes = ["bfloat16", "float32"]
 
 
 class RuntimePatchTests(unittest.TestCase):
@@ -101,6 +236,7 @@ class RuntimePatchTests(unittest.TestCase):
         self.fake_methods = {
             "attention_forward": _FakeAttention.forward,
             "block_forward": _FakeDiTBlock.forward,
+            "final_forward": _FakeFinalLayer.forward,
             "mlp_forward": _FakeMLP.forward,
             "layout_init": _FakePackedLayout.__init__,
             "model_init": _FakeModel.__init__,
@@ -110,18 +246,37 @@ class RuntimePatchTests(unittest.TestCase):
     def tearDown(self):
         _FakeAttention.forward = self.fake_methods["attention_forward"]
         _FakeDiTBlock.forward = self.fake_methods["block_forward"]
+        _FakeFinalLayer.forward = self.fake_methods["final_forward"]
         _FakeMLP.forward = self.fake_methods["mlp_forward"]
         _FakePackedLayout.__init__ = self.fake_methods["layout_init"]
         _FakeModel.__init__ = self.fake_methods["model_init"]
         _FakeModel._forward = self.fake_methods["model_forward"]
+        _FakeSupportedMiniMaxH3.supported_inference_dtypes = ["bfloat16", "float32"]
+        for name in (
+            "_minimax_h3_v100_supported_dtype_profile",
+            "_minimax_h3_v100_custom_node_profile",
+        ):
+            if hasattr(_FakeSupportedMiniMaxH3, name):
+                delattr(_FakeSupportedMiniMaxH3, name)
         sys.modules.clear()
         sys.modules.update(self.saved_modules)
 
-    def _install_fake_modules(self):
+    def _install_fake_modules(self, capability=(7, 0), cuda_available=True, fp16_predeclared=False):
         torch = types.ModuleType("torch")
+        torch.__path__ = []
         torch.float16 = "float16"
+        torch.bfloat16 = "bfloat16"
         torch.float32 = "float32"
-        torch.no_grad = contextlib.nullcontext
+        torch.cuda = types.SimpleNamespace(
+            is_available=lambda: cuda_available,
+            get_device_capability=lambda: capability,
+        )
+        torch_nn = types.ModuleType("torch.nn")
+        torch_nn.__path__ = []
+        torch_functional = types.ModuleType("torch.nn.functional")
+        torch_functional.silu = lambda value: value
+        torch_nn.functional = torch_functional
+        torch.nn = torch_nn
 
         comfy = types.ModuleType("comfy")
         comfy.__path__ = []
@@ -141,23 +296,49 @@ class RuntimePatchTests(unittest.TestCase):
         quant_ops.ck = types.SimpleNamespace(rms_rope_split_half_=lambda *args, **kwargs: None)
 
         model = types.ModuleType("comfy.ldm.minimax.model")
-        for cls in (_FakeAttention, _FakeDiTBlock, _FakeMLP, _FakePackedLayout, _FakeModel):
+        for cls in (
+            _FakeAttention,
+            _FakeDiTBlock,
+            _FakeFinalLayer,
+            _FakeMLP,
+            _FakePackedLayout,
+            _FakeModel,
+        ):
             cls.__module__ = model.__name__
-        _FakeAttention.forward.__module__ = model.__name__
-        _FakeDiTBlock.forward.__module__ = model.__name__
-        _FakeMLP.forward.__module__ = model.__name__
-        _FakePackedLayout.__init__.__module__ = model.__name__
-        _FakeModel.__init__.__module__ = model.__name__
-        _FakeModel._forward.__module__ = model.__name__
+        for function in self.fake_methods.values():
+            function.__module__ = model.__name__
         model.Attention = _FakeAttention
         model.DiTBlock = _FakeDiTBlock
+        model.FinalLayer = _FakeFinalLayer
         model.MLP = _FakeMLP
         model.PackedLayout = _FakePackedLayout
         model.MiniMaxH3Model = _FakeModel
 
+        def mod_scale_shift(value, shift, scale, segments):
+            value.trace.append(("mod_scale_shift", value.dtype))
+            return value
+
+        def mod_gate(value, gate, other, segments):
+            value.trace.append(("mod_gate", value.dtype, other.dtype))
+            return value
+
+        model._mod_scale_shift = mod_scale_shift
+        model._mod_gate = mod_gate
+
+        supported = types.ModuleType("comfy.supported_models")
+        _FakeSupportedMiniMaxH3.__module__ = supported.__name__
+        _FakeSupportedMiniMaxH3.supported_inference_dtypes = (
+            ["float16", "bfloat16", "float32"]
+            if fp16_predeclared
+            else ["bfloat16", "float32"]
+        )
+        supported.MiniMaxH3 = _FakeSupportedMiniMaxH3
+
         sys.modules.update(
             {
                 "torch": torch,
+                "torch.nn": torch_nn,
+                "torch.nn.functional": torch_functional,
                 "comfy": comfy,
                 "comfy.ldm": ldm,
                 "comfy.ldm.minimax": minimax,
@@ -166,103 +347,247 @@ class RuntimePatchTests(unittest.TestCase):
                 "comfy.ldm.modules.attention": attention,
                 "comfy.model_management": management,
                 "comfy.quant_ops": quant_ops,
+                "comfy.supported_models": supported,
             }
         )
         comfy.ldm = ldm
         comfy.model_management = management
         comfy.quant_ops = quant_ops
+        comfy.supported_models = supported
         ldm.minimax = minimax
         minimax.model = model
-        return model
+        return model, supported
 
     def _load_runtime(self):
-        spec = importlib.util.spec_from_file_location("test_minimax_h3_runtime_patch", self.runtime_path)
+        spec = importlib.util.spec_from_file_location("test_minimax_h3_v013_runtime", self.runtime_path)
         module = importlib.util.module_from_spec(spec)
         sys.modules[spec.name] = module
         spec.loader.exec_module(module)
         return module
 
-    def test_install_marks_only_main_blocks_and_captures_audio_ranges(self):
-        model_module = self._install_fake_modules()
+    def test_registers_native_fp16_and_marks_only_native_fp16_main_blocks(self):
+        model_module, supported = self._install_fake_modules()
         runtime = self._load_runtime()
-
         self.assertTrue(runtime.PATCH_STATUS["installed"])
-        self.assertEqual(runtime.PATCH_STATUS["version"], "0.1.2")
-        model = model_module.MiniMaxH3Model(num_layers=3)
-        self.assertEqual(len(model.blocks), 3)
+        self.assertEqual(runtime.PACKAGE_VERSION, "0.1.3")
+        self.assertEqual(
+            supported.MiniMaxH3.supported_inference_dtypes,
+            ["float16", "bfloat16", "float32"],
+        )
+
+        model = model_module.MiniMaxH3Model(num_layers=3, dtype="float16", operations=object())
         for block in model.blocks:
+            self.assertTrue(getattr(block, runtime._BLOCK_ENABLE_FLAG))
             self.assertTrue(getattr(block.attn, runtime._ATTENTION_ENABLE_FLAG))
-            self.assertTrue(getattr(block.attn, runtime._QKV_WEIGHT_FLAG))
+            self.assertTrue(getattr(block.mlp, runtime._MLP_ENABLE_FLAG))
+        self.assertTrue(getattr(model.final_layer, runtime._FINAL_ENABLE_FLAG))
         for block in model.token_refiner.blocks:
+            self.assertFalse(hasattr(block, runtime._BLOCK_ENABLE_FLAG))
             self.assertFalse(hasattr(block.attn, runtime._ATTENTION_ENABLE_FLAG))
+            self.assertFalse(hasattr(block.mlp, runtime._MLP_ENABLE_FLAG))
 
+        value = _TraceTensor("condition", "float16")
+        result = model.condition_proj(value)
+        self.assertEqual(model.condition_proj.inputs, ["float32"])
+        self.assertEqual(result.dtype, "float32")
+
+    def test_fp32_forced_model_instance_stays_unmodified(self):
+        model_module, _ = self._install_fake_modules()
+        runtime = self._load_runtime()
+        model = model_module.MiniMaxH3Model(dtype="float32", operations=object())
+        for block in model.blocks:
+            self.assertFalse(hasattr(block, runtime._BLOCK_ENABLE_FLAG))
+            self.assertFalse(hasattr(block.attn, runtime._ATTENTION_ENABLE_FLAG))
+            self.assertFalse(hasattr(block.mlp, runtime._MLP_ENABLE_FLAG))
+        self.assertFalse(hasattr(model.final_layer, runtime._FINAL_ENABLE_FLAG))
+        self.assertFalse(hasattr(model.condition_proj, runtime._CONDITION_WRAPPED_FLAG))
+
+    def test_audio_ranges_are_captured_and_reset(self):
+        model_module, _ = self._install_fake_modules()
+        runtime = self._load_runtime()
+        model = model_module.MiniMaxH3Model(dtype="float16", operations=object())
         layout = model_module.PackedLayout(2, 3, 4, 5, 6)
-        self.assertEqual(getattr(layout, runtime._LAYOUT_RANGES_ATTR), ((2, 14),))
-        self.assertEqual(runtime._ranges_from_layout(layout), ((2, 14),))
-
-        inside_existing = model._forward(
+        expected = ((2, 8), (8, 20))
+        self.assertEqual(runtime._ranges_from_layout(layout), expected)
+        inside = model._forward(
             None,
             None,
             None,
             transformer_options={"probe": runtime._AUDIO_RANGES.get},
             minimax_payload={"layout": layout},
         )
-        inside_new = model._forward(
-            None,
-            None,
-            None,
-            transformer_options={"probe": runtime._AUDIO_RANGES.get},
-            minimax_payload=None,
-        )
-        self.assertEqual(inside_existing, ((2, 14),))
-        self.assertEqual(inside_new, ((2, 14),))
+        self.assertEqual(inside, expected)
         self.assertEqual(runtime._AUDIO_RANGES.get(), ())
 
-    def test_audio_ranges_fail_closed_when_invalid(self):
-        self._install_fake_modules()
+    def test_block_trace_promotes_residual_and_demotes_only_branches(self):
+        _, _ = self._install_fake_modules()
         runtime = self._load_runtime()
-        self.assertEqual(runtime._normalize_ranges(((1, 3), (4, 6)), 6), ((1, 3), (4, 6)))
-        self.assertEqual(runtime._normalize_ranges(((1, 7),), 6), ())
-        self.assertEqual(runtime._normalize_ranges((("bad", 3),), 6), ())
+        trace = []
+
+        class Branch:
+            def __init__(self, name):
+                self.name = name
+
+            def __call__(self, value, **kwargs):
+                trace.append((self.name, value.dtype))
+                return _TraceTensor(f"{self.name}_out", "float32", trace)
+
+        block = types.SimpleNamespace(
+            adaln_proj=_FakeAdaln(),
+            norm1=_FakeNorm(),
+            norm2=_FakeNorm(),
+            attn=Branch("attention"),
+            mlp=Branch("mlp"),
+        )
+        setattr(block, runtime._BLOCK_ENABLE_FLAG, True)
+        x = _TraceTensor("residual", "float16", trace)
+        t_emb = _TraceTensor("t_emb", "float16", trace)
+        result = runtime._patched_block_forward(block, x, t_emb, (), None, {})
+        self.assertEqual(result.dtype, "float32")
+        self.assertIn(("residual.to", "float32"), trace)
+        self.assertIn(("t_emb.to", "float32"), trace)
+        self.assertIn(("attention", "float16"), trace)
+        self.assertIn(("mlp", "float16"), trace)
+        self.assertIn(("mod_gate", "float32", "float32"), trace)
+
+    def test_mlp_trace_uses_native_fp16_gemms_and_fp32_swiglu(self):
+        _, _ = self._install_fake_modules()
+        runtime = self._load_runtime()
+        mlp = _FakeMLP()
+        setattr(mlp, runtime._MLP_ENABLE_FLAG, True)
+        trace = []
+
+        def traced_silu(value):
+            trace.append(("silu", value.dtype))
+            return _TraceTensor("silu_gate", value.dtype, trace)
+
+        runtime.F.silu = traced_silu
+        result = runtime._patched_mlp_forward(mlp, _TraceTensor("x", "float16", trace))
+        self.assertEqual(result.dtype, "float32")
+        self.assertEqual(
+            trace,
+            [
+                ("fc1", "float16"),
+                ("fc1_out.chunk", 2, -1),
+                ("gate.to", "float32"),
+                ("silu", "float32"),
+                ("value.to", "float32"),
+                ("silu_gate.mul_", "value", "float32", "float32"),
+                ("silu_gate/", 256.0, "float32"),
+                ("silu_gate.to", "float16"),
+                ("fc2", "float16"),
+                ("fc2_out.to", "float32"),
+                ("fc2_out.mul_", 256.0, "float32"),
+            ],
+        )
+
+    def test_final_layer_promotes_modulation_and_both_heads_to_fp32(self):
+        _, _ = self._install_fake_modules()
+        runtime = self._load_runtime()
+        final_layer = _FakeFinalLayer()
+        setattr(final_layer, runtime._FINAL_ENABLE_FLAG, True)
+        trace = []
+        video, audio = runtime._patched_final_forward(
+            final_layer,
+            _TraceTensor("final_x", "float16", trace),
+            _TraceTensor("final_t", "float16", trace),
+            (0, 4, 0),
+            (4, 8, 1),
+        )
+        self.assertEqual(video.dtype, "float32")
+        self.assertEqual(audio.dtype, "float32")
+        self.assertIn(("final_x.to", "float32"), trace)
+        self.assertIn(("final_t.to", "float32"), trace)
+        self.assertIn(("video_out", "float32"), trace)
+        self.assertIn(("audio_out", "float32"), trace)
+
+    def test_non_v100_device_disables_before_dtype_registration(self):
+        _, supported = self._install_fake_modules(capability=(8, 0))
+        runtime = self._load_runtime()
+        self.assertFalse(runtime.PATCH_STATUS["installed"])
+        self.assertIn("not the V100 target", runtime.PATCH_STATUS["reason"])
+        self.assertEqual(supported.MiniMaxH3.supported_inference_dtypes, ["bfloat16", "float32"])
+
+    def test_predeclared_fp16_is_treated_as_conflict(self):
+        _, supported = self._install_fake_modules(fp16_predeclared=True)
+        runtime = self._load_runtime()
+        self.assertFalse(runtime.PATCH_STATUS["installed"])
+        self.assertIn("already exposes FP16", runtime.PATCH_STATUS["reason"])
+        self.assertEqual(
+            supported.MiniMaxH3.supported_inference_dtypes,
+            ["float16", "bfloat16", "float32"],
+        )
 
     def test_install_is_idempotent(self):
         self._install_fake_modules()
         runtime = self._load_runtime()
         second = runtime.install_patch()
         self.assertTrue(second["installed"])
-        self.assertEqual(second["version"], "0.1.2")
+        self.assertEqual(second["version"], "0.1.3")
         self.assertEqual(second["reason"], "already installed")
 
-    def test_conflicting_mlp_monkey_patch_disables_profile(self):
-        model_module = self._install_fake_modules()
+    def test_late_conflict_keeps_new_instances_unmodified(self):
+        model_module, _ = self._install_fake_modules()
+        runtime = self._load_runtime()
 
-        def foreign_mlp_forward(self, x):
+        def foreign_mlp(self, x):
             return x
 
-        foreign_mlp_forward.__module__ = "another_h3_extension"
-        model_module.MLP.forward = foreign_mlp_forward
-        runtime = self._load_runtime()
-        self.assertFalse(runtime.PATCH_STATUS["installed"])
-        self.assertIn("MLP.forward", runtime.PATCH_STATUS["reason"])
-
-    def test_late_conflict_keeps_new_model_instances_unmodified(self):
-        model_module = self._install_fake_modules()
-        runtime = self._load_runtime()
-        self.assertTrue(runtime.PATCH_STATUS["installed"])
-
-        def foreign_mlp_forward(self, x):
-            return x
-
-        foreign_mlp_forward.__module__ = "another_h3_extension"
-        model_module.MLP.forward = foreign_mlp_forward
-        model = model_module.MiniMaxH3Model(num_layers=2)
+        foreign_mlp.__module__ = "another_extension"
+        model_module.MLP.forward = foreign_mlp
+        model = model_module.MiniMaxH3Model(dtype="float16", operations=object())
         for block in model.blocks:
-            self.assertFalse(hasattr(block.attn, runtime._ATTENTION_ENABLE_FLAG))
+            self.assertFalse(hasattr(block, runtime._BLOCK_ENABLE_FLAG))
+
+    def test_source_contract_has_no_lazy_weight_mutation(self):
+        self._install_fake_modules()
+        runtime = self._load_runtime()
+        source = self.runtime_path.read_text(encoding="utf-8")
+        self.assertEqual(runtime.OUT_PROJ_SCALE, 64.0)
+        self.assertEqual(runtime.MLP_FC2_SCALE, 256.0)
+        self.assertNotIn("weight.data", source)
+        self.assertNotIn("_prepare_fp16_weights", source)
+        self.assertIn("supported_inference_dtypes", source)
+        self.assertIn("audio_q = q.to(dtype=torch.float32)", source)
+        self.assertIn("out.squeeze(0) / OUT_PROJ_SCALE", source)
+        self.assertIn("hidden / MLP_FC2_SCALE", source)
+        self.assertIn("t_emb = t_emb.to(dtype=torch.float32)", source)
+        self.assertIn("self.video_out(hv.to(dtype=torch.float32))", source)
+        self.assertIn("self.audio_out(ha.to(dtype=torch.float32))", source)
 
     def test_runtime_code_has_no_source_file_write_api(self):
         source = self.runtime_path.read_text(encoding="utf-8")
-        for forbidden in ("open(", "write_text(", "write_bytes(", "replace(", "shutil.", "os.rename"):
+        for forbidden in ("open(", "write_text(", "write_bytes(", "shutil.", "os.rename"):
             self.assertNotIn(forbidden, source)
+
+    def test_runtime_contains_no_allocator_debug_telemetry(self):
+        source = self.runtime_path.read_text(encoding="utf-8")
+        self.assertNotIn("empty_cache", source)
+        self.assertNotIn("reset_peak_memory_stats", source)
+        self.assertNotIn("_memory_report", source)
+        self.assertNotIn("memory_allocated", source)
+        self.assertNotIn("memory_reserved", source)
+        self.assertNotIn("max_memory_allocated", source)
+        self.assertNotIn("mem_get_info", source)
+        self.assertNotIn("oom-forward", source)
+
+    def test_core_compute_functions_match_promoted_l3_release(self):
+        candidate = ast.parse(self.runtime_path.read_text(encoding="utf-8"))
+        expected = {
+            "_patched_attention_forward": "d423ee3d5e20c19d4219c133a7c32459ef37a3d3135df6436ba47a4d90d4adb3",
+            "_patched_mlp_forward": "aa8b8c08b1d41d7dd0a0ef3bfd124f72293130697865014443016ad8b336f9ef",
+            "_patched_final_forward": "96582fee3f8b3c661aabbaeb484f2e8e4efc2dfd589801e3648e413cd590d394",
+            "_patched_block_forward": "866c73f012a7f6c62e1c84a207832c184ff1d335f499d72da3200845b79496ee",
+        }
+
+        for name, expected_hash in expected.items():
+            node = next(
+                item
+                for item in candidate.body
+                if isinstance(item, ast.FunctionDef) and item.name == name
+            )
+            payload = ast.dump(node, include_attributes=False).encode("utf-8")
+            self.assertEqual(hashlib.sha256(payload).hexdigest(), expected_hash)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed

- Promotes the successful, debug-free L3 profile to the formal v0.1.3 Custom Node release.
- Keeps MiniMax H3 weights resident in native FP16 through ComfyUI loading, prefetch, and offload.
- Expands FP16 attention and MLP hot paths while retaining FP32 residual, audio-attention, modulation, Token Refiner, and final-output safety islands.
- Adds power-of-two scaling around FP16 `out_proj` and MLP `fc2`.
- Removes allocator/OOM debug telemetry from the production runtime.
- Updates English and Chinese documentation, NOTICE, version metadata, and manifest hashes.

## Why

The promoted L3 profile reduces inference-period resident VRAM without changing measured inference performance. The user has also confirmed that v0.1.3 runs with ComfyUI 0.33.2.

## User impact

The release remains a drop-in Custom Node with no workflow node and no ComfyUI source modification. It is V100/SM70-only and fails closed on unsupported H3 structures or conflicting precision patches.

This is the standalone L3 release. It must not be stacked with TE-Speed or another H3 runtime/dtype patch; the separate L3-TE adapter is not included in this PR.

## Validation

- 14 dependency-free runtime and dtype-flow tests passed.
- Python AST parsing passed for the loader, runtime, tests, and unchanged legacy patch core.
- Promoted compute-kernel AST hashes match the successful L3 profile.
- Manifest size and SHA-256 entries verified for all 20 tracked payload files.
- `git diff --check` passed.
- `legacy_patcher/` is unchanged.
