### PR TITLE
Release v0.1.4: support updated ComfyUI MiniMax H3 API

### DIFF
--- a/MANIFEST.json
+++ b/MANIFEST.json
@@ -1,110 +1,66 @@
 {
   "package": "minimax-h3-v100-patch",
-  "version": "0.1.3",
-  "profile_id": "minimax-h3-v100-v013-native-fp16-branches",
-  "default_delivery": "standalone ComfyUI Custom Node runtime extension",
-  "profile": "native FP16 storage and attention/MLP branches; FP32 residual, audio recomputation, modulation, Token Refiner and final heads",
-  "compatibility": "user-reported V100 runtime success on ComfyUI 0.33.2",
-  "generated_date": "2026-08-18",
-  "runtime_status": "successful L3 V100 run with reduced resident VRAM and unchanged inference performance",
-  "known_clean_origin_sha256": "1c9828ec3d38ac01398e45b1edf8d7db38fcc8148c5eb3ba8fb92b762147d0ce",
+  "version": "0.1.4",
+  "profile_id": "minimax-h3-v100-v014-native-fp16-branches",
+  "install_folder": "minimax-h3-v100-l3-clean",
+  "generated_date": "2026-09-06",
+  "compatibility": "ComfyUI v0.34.5 and PDD source fixtures; see tests/fixtures/PROVENANCE.json",
+  "runtime_status": "V100 server inference, quality, speed and memory tests pending",
+  "validation": {
+    "python_ast": "passed",
+    "dependency_free_tests": 23,
+    "upstream_final_argument_and_dtype_flow": "passed",
+    "real_torch_numerical_tests": "not run",
+    "gpu_inference": "not run"
+  },
   "files": {
-    ".gitignore": {
-      "bytes": 60,
-      "sha256": "baa446a8c82fb3e01c62f3b415d0b82440606e27ed8e5286b04773a49db1a923"
-    },
     "__init__.py": {
       "bytes": 418,
-      "sha256": "bc63357ca68525055f744a09a5e432c936643ef8d7df20bd8436e4fd4f22e472"
+      "sha256": "501b469926b663b2e7cdada2476ad55eb5961e4156c6c10312899bbd6922a0b3"
+    },
+    "runtime_patch.py": {
+      "bytes": 24549,
+      "sha256": "5417d007fa3efbc6c62773b8a7b84e14899321f8d58af7c6c78b8a36ea2de484"
+    },
+    "README.md": {
+      "bytes": 4780,
+      "sha256": "15680bfcb0e305f253ac5989e4421ecd5d704cc4d1f63edd5a9616470d6c8188"
+    },
+    "README_zh-CN.md": {
+      "bytes": 4338,
+      "sha256": "e22cce3ddbe09c221408ef2ed39fe9666659a9d64701fd8317e042c49026cf37"
+    },
+    "NOTICE.md": {
+      "bytes": 1960,
+      "sha256": "b55c45b86935389617122fd65f0816b9af513cc2c3035b2c30019b7275fb7ca7"
     },
     "LICENSE": {
       "bytes": 35149,
       "sha256": "3972dc9744f6499f0f9b2dbf76696f2ae7ad8af9b23dde66d6af86c9dfb36986"
     },
-    "NOTICE.md": {
-      "bytes": 3763,
-      "sha256": "f3aafb311147b9267254d2bd0e490d32dc2fff8dfc1054f1d1c96694a1fbfd30"
-    },
-    "README.md": {
-      "bytes": 8586,
-      "sha256": "0ba0ab7116ad1e233b61e56a7b8091e156ca31d7055d23bf063f1ab62dc9a272"
-    },
-    "README_zh-CN.md": {
-      "bytes": 8285,
-      "sha256": "01aca564e806f3ae4ed37b90ddc8e74eabb0db58f5e5e14bbe1d55d782c4f7c3"
-    },
-    "runtime_patch.py": {
-      "bytes": 23671,
-      "sha256": "217f7db113b1d33ab134ff8d75a9081bf421be50202f9db008a03d3ae41641d0"
-    },
     "tests/test_runtime_patch.py": {
-      "bytes": 23093,
-      "sha256": "f83a9d45972278c1ca6b04cc8b1b54af5a837a9d3950a15d1c1a896ddb8c7b3d"
+      "bytes": 22998,
+      "sha256": "d6d2b9090c0384c50ca6e16a4ca68a9d298ea054bec4ae6c5f4abb580c2fe281"
     },
-    "legacy_patcher/_patch_core.py": {
-      "bytes": 31005,
-      "sha256": "90d9dd86a8f57f61e9fe61ef247196619a1e1b6dca68055da49729ebdf9c3330"
+    "tests/test_upstream_compat.py": {
+      "bytes": 8833,
+      "sha256": "fb78808935e2ab24b3626c9ab606197f0a0bffd6845b1fc9e0bab84f762f0cb8"
     },
-    "legacy_patcher/LICENSE": {
-      "bytes": 35823,
-      "sha256": "230184f60bae2feaf244f10a8bac053c8ff33a183bcc365b4d8b876d2b7f4809"
+    "tests/fixtures/model_v0345.py": {
+      "bytes": 37476,
+      "sha256": "b3f51bfd5c44962c3bbe09c3e16e34698a286c5279e050ea6c3defbb8434c34e"
     },
-    "legacy_patcher/MANIFEST.json": {
-      "bytes": 2738,
-      "sha256": "6138d06482654b95b4cdd1fee45da6037dfa31bf3523c579dd0174a839bd104e"
+    "tests/fixtures/model_pdd.py": {
+      "bytes": 40295,
+      "sha256": "648182d0368047ea77864494b2675ca3f09d0fc2c857f53bb989adff947e17c6"
     },
-    "legacy_patcher/NOTICE.md": {
-      "bytes": 3633,
-      "sha256": "8639b89d16248ed0d925a5ac96d01cd809034c0bd2e6e4b438566fea54f8aaa3"
+    "tests/fixtures/PROVENANCE.json": {
+      "bytes": 728,
+      "sha256": "90777d4161e59bd830546a3432d273c248a850b54c01a67d8d2268d35cfa9b3c"
     },
-    "legacy_patcher/patch_h3_origin_v100.bat": {
-      "bytes": 1370,
-      "sha256": "6b4fb48117b7d29ae7bb4ae5ddbd0d4236fc79327c18a41b7ff62de8e3e3ecd3"
-    },
-    "legacy_patcher/patch_h3_origin_v100.py": {
-      "bytes": 236,
-      "sha256": "cd5a62f4151cfac57eab149d216d830f188292a6ba31c39a72f4fc3d5d345483"
-    },
-    "legacy_patcher/patch_te_v100.bat": {
-      "bytes": 1559,
-      "sha256": "443c315b4d2020ba6c4aaea2a9d09d6a0e2a6dbeefe9bbcf838effa806316501"
-    },
-    "legacy_patcher/patch_te_v100.py": {
-      "bytes": 257,
-      "sha256": "2e7063f412cadec3d9eab4a363d3b779a23314f76c17af260d596cf5c57b0de0"
-    },
-    "legacy_patcher/restore_h3_origin_v100.bat": {
-      "bytes": 291,
-      "sha256": "9efbb28523f8f2e21a49b5e068d4d79dbcade4f70b292d94dbbc7c966d6869ac"
-    },
-    "legacy_patcher/restore_te_v100.bat": {
-      "bytes": 1634,
-      "sha256": "920f248cd6776464bdaf6349fb4aa5049371eb90884008301d999d69c2ed0fd9"
-    },
-    "legacy_patcher/sources/origin_v100/model.py": {
-      "bytes": 37337,
-      "sha256": "a65a605f2b6476db1c4e25f42ccfd660620f53b72ddc1bc494a5ac14a2bd01f5"
-    },
-    "legacy_patcher/sources/te_v100/model.py": {
-      "bytes": 38605,
-      "sha256": "c96ede0c7c3f355deae37f445284d51dc6b2442529c9a48cadbf991449bd8637"
+    "tools/build_release.py": {
+      "bytes": 3817,
+      "sha256": "4904924ec63cf7f335f5b38bdfb33bd5448962b5c820d842e26b117b8dfa21a5"
     }
-  },
-  "validation": {
-    "python_ast": "passed",
-    "simulated_loader_tests": "passed (14 tests)",
-    "runtime_version_reporting": "passed (0.1.3)",
-    "v100_only": "passed",
-    "native_fp16_registration": "passed",
-    "main_dit_only": "passed",
-    "token_refiner_excluded": "passed",
-    "fp32_audio_and_final_safety": "passed",
-    "l3_compute_kernel_hashes": "passed",
-    "early_and_late_runtime_conflicts": "passed",
-    "lazy_weight_mutation_absent": "passed",
-    "allocator_debug_telemetry_absent": "passed",
-    "source_write_api_absent": "passed",
-    "legacy_origin_patch_restore_roundtrip": "carried forward unchanged from v0.1.2",
-    "legacy_origin_to_te_patch_restore_roundtrip": "carried forward unchanged from v0.1.2"
   }
 }

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,57 +1,13 @@
 # Provenance and validation notice
 
-## Release
+Version: 0.1.4. Date: 2026-09-06. Target: CUDA compute capability 7.0 (Volta/V100).
 
-- Package version: `0.1.3`
-- Default delivery: standalone ComfyUI Custom Node loaded at runtime
-- Target GPU: NVIDIA Tesla V100 / CUDA compute capability 7.0
-- Current reported compatibility: ComfyUI `0.33.2`
-- Profile: successful L3 native-FP16 storage/branch profile with FP32 safety islands
+This standalone Custom Node extends the v0.1.3 native-FP16 L3 release. Attention and MLP compute-function AST hashes are unchanged. FinalLayer now delegates upstream after promoting x and t_emb to FP32; all trailing positional and keyword arguments survive. This retains upstream modulation/PDD semantics. The DiT wrapper also supports the upstream optional attention override. Unknown parameters on reimplemented methods disable installation before dtype registration.
 
-## Precision-profile provenance
+Local validation: 23 dependency-free tests pass, including execution of real v0.34.5/PDD FinalLayer source bodies with trace tensors. PDD arithmetic is replaced by a spy; argument routing, schedule interval selection, per-stream shifts and FP32 flow are checked. No real PyTorch tensor, V100 inference, image/audio quality, memory or speed result is claimed for v0.1.4. Earlier 0.1.3 runtime results are historical only.
 
-Version 0.1.3 promotes the successful, debug-free L3 profile to the formal release:
+Upstream source fixtures are unchanged ComfyUI model.py snapshots retrieved on 2026-09-06. They are test data, never installed over ComfyUI. Their URLs and SHA-256 digests are recorded in tests/fixtures/PROVENANCE.json. The current-master snapshot was verified against fixed commit 15eb748b3ec5f8a0a2d470b7fb280e2d7579f916.
 
-- Native FP16 weights through ComfyUI loading, prefetch and offload.
-- FP16 QKV, Q/K RMSNorm, RoPE and text/video attention in the main DiT blocks.
-- FP32 target/reference-audio attention recomputation.
-- Power-of-two scaling around FP16 attention output projection and MLP `fc2`.
-- FP32 main residual, Block Norm, AdaLN/modulation, condition input, Token Refiner, SwiGLU intermediates, final AdaLN and video/audio heads.
+The v0.1.4 distribution excludes TE adapters, TE-Speed and legacy source patchers. It must be installed as the only H3 precision runtime extension. It does not rewrite ComfyUI source files, mutate weight.data or retain a full FP32 weight mirror. Preserve the FP32 safety paths during server validation.
 
-Full-FP16 final heads remain excluded. The implementation does not mutate `weight.data`, retain a complete FP32 weight mirror across blocks, or convert full weights inside `forward`.
-
-## Runtime implementation
-
-- Registers FP16 as a supported MiniMax H3 inference dtype before model construction so ComfyUI owns the FP16 weight lifecycle.
-- Enables the profile only on native-FP16 main DiT blocks; the Token Refiner remains outside the accelerated block profile.
-- Preserves target/reference-audio row ranges through task-local runtime context.
-- Uses `/64 → FP16 out_proj → FP32 ×64` and `/256 → FP16 fc2 → FP32 ×256`.
-- Forces `condition_proj` input and both final output heads through FP32 safety paths.
-- Refuses unsupported GPUs, unfamiliar ComfyUI H3 structures, source patches, pre-existing FP16 dtype providers and late runtime conflicts.
-- Contains no per-forward allocator telemetry, OOM diagnostic interception, cache clearing, CUDA synchronization or peak-counter reset.
-- Does not modify any ComfyUI source file.
-
-## Validation completed on 2026-08-18
-
-- The user reported that the L3 profile successfully reduced inference-period resident VRAM while keeping inference performance unchanged.
-- The user reported successful operation with ComfyUI 0.33.2.
-- Fourteen dependency-free tests cover version reporting, V100 restriction, native-FP16 registration, main-block/Token-Refiner isolation, dtype flow, FP32 audio/final safety, power-of-two scaling, idempotence, early/late conflict refusal, no lazy weight mutation, no source writes and no allocator debug telemetry.
-- The promoted release compute-kernel AST hashes match the successful L3 profile.
-
-Target-GPU results remain workload-specific; users should hold model, seed, prompt, sampler, steps, dimensions, attention backend, offload mode and power limit constant when comparing releases.
-
-## Compatibility boundary
-
-This is the standalone v0.1.3 runtime profile. It must not be stacked with TE-Speed or another H3 runtime/dtype patch. A separately reviewed adapter is required for combined execution.
-
-## Legacy patcher
-
-The earlier guarded source patchers, restore scripts, source snapshots, their original manifest and detailed provenance notice remain under `legacy_patcher/`. They are retained for recovery and development and are not the recommended v0.1.3 installation path.
-
-## Acknowledgement
-
-Thanks to [Amduraznak/minimax-h3-fp16-fix](https://github.com/Amduraznak/minimax-h3-fp16-fix) for demonstrating a practical ComfyUI Custom Node delivery pattern and the native-FP16/FP32-residual design with power-of-two projection scaling. This is a community extension, not an official MiniMax, ComfyUI, NVIDIA, PyTorch, TE-Speed or acknowledged-project release.
-
-## Licensing
-
-SPDX-License-Identifier: GPL-3.0-only. See `LICENSE`. The acknowledged project is separately licensed by its author.
+Thanks to ComfyUI, MiniMax and Amduraznak/minimax-h3-fp16-fix for the Custom Node pattern and related mixed-precision design. This is not an official release of those projects. ComfyUI-derived code and this extension are distributed under GPL-3.0-only; see LICENSE. The acknowledged project retains its own license.

--- a/README.md
+++ b/README.md
@@ -1,139 +1,61 @@
-# MiniMax H3 V100 mixed precision — Custom Node v0.1.3
+# MiniMax H3 V100 — Custom Node v0.1.4
 
 English | [简体中文](README_zh-CN.md)
 
-**Version 0.1.3 reduces resident VRAM usage while keeping inference performance unchanged. It has been successfully run with ComfyUI 0.33.2.**
+Version 0.1.4 fixes `TypeError: _patched_final_forward() takes 5 positional arguments but 8 were given` while retaining the standalone L3 FP16 storage/branch profile and FP32 safety islands. This release has local structural/argument/dtype-flow validation; **V100 inference, output quality and performance are pending server testing**.
 
-Version **0.1.3** promotes the successful L3 mixed-precision profile to the official Custom Node release. Model weights now remain FP16 through ComfyUI loading, prefetch and offload, while numerically sensitive residual, audio and output paths retain FP32 safety islands.
+## Install / update
 
-The Custom Node does not rewrite `comfy/ldm/minimax/model.py`, does not require a modified launch command, and can be removed by deleting one folder and restarting ComfyUI. Earlier v0.1.2 builds were also reported working on ComfyUI 0.31.1 and 0.32.0.
-
-The previous source-modifying installers are still available under [`legacy_patcher/`](legacy_patcher/) for recovery, development, and users who explicitly need them.
-
-## Recommended Custom Node installation
-
-### Before installing
-
-Use a clean, unpatched ComfyUI `comfy/ldm/minimax/model.py`. If an earlier release of this project modified that file, first stop ComfyUI and restore it with the matching script:
-
-```bat
-legacy_patcher\restore_te_v100.bat "D:\ComfyUI\comfy\ldm\minimax\model.py"
-legacy_patcher\restore_h3_origin_v100.bat "D:\ComfyUI\comfy\ldm\minimax\model.py"
-```
-
-The runtime extension intentionally refuses to stack on top of the old source patch or another H3 monkey patch.
-
-### Install
-
-1. Stop ComfyUI.
-2. Download or clone this repository.
-3. Put the complete repository folder under `ComfyUI/custom_nodes/`. The important layout is:
+1. Fully stop ComfyUI.
+2. Remove the previous H3 extension folder from `custom_nodes` (including old `minimax-h3-v100-l3-clean`, `minimax-h3-v100-patch`, or preview copies). Remove `minimax-h3-v100-l3-te` and TE-Speed if installed. Keep only one H3 precision extension.
+3. Extract `minimax-h3-v100-v0.1.4.zip` into the active `custom_nodes` directory. The ZIP has one top-level folder:
 
    ```text
-   ComfyUI/
-   └─ custom_nodes/
-      └─ minimax-h3-v100-patch/
-         ├─ __init__.py
-         ├─ runtime_patch.py
-         ├─ README.md
-         └─ legacy_patcher/
+   custom_nodes/minimax-h3-v100-l3-clean/__init__.py
+   custom_nodes/minimax-h3-v100-l3-clean/runtime_patch.py
    ```
 
-4. Start ComfyUI normally. Do **not** add `--fp16-unet`, `--force-fp16`, or another precision flag for this profile.
-5. Confirm that the startup log contains:
+   In the supplied error report that directory is `C:\Comfyui\custom_nodes`.
+4. Restart ComfyUI normally. No new workflow node or `--fp16-unet` flag is needed. Use an official, unmodified ComfyUI `comfy/ldm/minimax/model.py`.
+5. Confirm the startup log contains `v0.1.4 runtime profile installed`, then model loading reports `enabled v0.1.4` on the main DiT blocks.
 
-   ```text
-   [MiniMax H3 V100] v0.1.3 runtime profile installed: v0.1.3: native FP16 storage/branches + FP32 safety islands
-   [MiniMax H3 V100] registered native FP16 H3 loading for CUDA capability 7.0 (Volta/V100); no --fp16-unet flag is required
-   ```
+The ZIP contains no TE adapter or legacy source patcher. If a source patch was previously applied, restore the matching official ComfyUI source before loading this extension. Uninstall by removing the extension folder and restarting; the extension never writes ComfyUI source files.
 
-The first H3 model load also reports how many main DiT blocks were enabled. The extension adds no workflow node; existing MiniMax H3 workflows continue to be used normally.
+## Compatibility fix
 
-### Update or uninstall
+The official `v0.34.5` tag has the four-input FinalLayer API. The supplied traceback identifies ComfyUI `0.34.0`, but its H3 source calls the newer seven-input API (`sigma`, `sample_sigmas`, `shifts` added). Version strings alone therefore do not identify the H3 interface.
 
-- Update: stop ComfyUI, replace this repository folder with the new version, and restart.
-- Uninstall: delete this repository folder from `custom_nodes` and restart. No ComfyUI source backup needs to be restored when only the Custom Node mode was used.
+- Both FinalLayer APIs are supported. The wrapper promotes hidden state and time embedding to FP32, then calls the original upstream method with every positional and keyword argument intact.
+- Upstream modulation row handling, PDD head-bank selection, schedule errors and stream-specific shift weighting remain upstream-owned.
+- The newer DiT block `attention` override is supported. Legacy block calls do not receive the new keyword when it is absent.
+- Unknown parameters on reimplemented Attention/MLP/DiT methods disable installation before FP16 dtype registration.
 
-## v0.1.3 memory and precision split
+Verified source fixtures: [ComfyUI v0.34.5](https://github.com/Comfy-Org/ComfyUI/blob/v0.34.5/comfy/ldm/minimax/model.py) and [PDD source at 15eb748b](https://github.com/Comfy-Org/ComfyUI/blob/15eb748b3ec5f8a0a2d470b7fb280e2d7579f916/comfy/ldm/minimax/model.py). Full source hashes are in `tests/fixtures/PROVENANCE.json`.
 
-- Native FP16 model storage through ComfyUI loading, prefetch and offload.
-- FP16 QKV, Q/K RMSNorm, RoPE and text/video attention in the 50 main DiT blocks.
-- FP32 target/reference-audio attention recomputation.
-- Scaled attention output projection: `/64 → FP16 out_proj → FP32 ×64`.
-- FP16 MLP `fc1`, FP32 SwiGLU, and scaled `fc2`: `/256 → FP16 fc2 → FP32 ×256`.
-- FP32 main residual stream, Block Norm, AdaLN/modulation, condition input, Token Refiner, final AdaLN and video/audio output heads.
+## Precision profile
 
-Full-FP16 final heads remain deliberately excluded. Version 0.1.3 obtains its memory reduction from native FP16 residency rather than converting full weights inside `forward`; it does not retain a full FP32 weight mirror across blocks.
+- Native FP16 weights through ComfyUI loading, prefetch and offload.
+- FP16 attention and MLP branches in main DiT blocks; FP32 target/reference-audio attention recomputation.
+- Attention output scaling: `/64 → FP16 projection → FP32 ×64`.
+- MLP: FP16 `fc1`, FP32 SwiGLU, `/256 → FP16 fc2 → FP32 ×256`.
+- FP32 residual, normalization/modulation, condition input, Token Refiner and final heads.
+- CUDA compute capability 7.0 restriction, duplicate-extension checks and no lazy `weight.data` conversion remain in place.
 
-## Runtime safety
+The attention and MLP compute functions retain their v0.1.3 AST hashes. The previous v0.1.3 documentation records successful ComfyUI 0.33.2 testing and reduced resident VRAM; that is historical evidence, not a measured result for v0.1.4.
 
-- Checks the current `Attention`, `DiTBlock`, `MLP`, `MiniMaxH3Model`, and `PackedLayout` structure before installation.
-- Refuses source-level V100 patches and other extensions that already own critical H3 methods.
-- Rechecks for extensions loaded later and keeps new model instances unmodified if a conflict appears.
-- Installs idempotently.
-- Missing or invalid audio row metadata fails closed to full FP32 attention for that call.
-- Refuses a second extension or source patch that already exposes a conflicting H3 FP16 path.
-- Does not mutate `weight.data`, cache complete FP32 weight mirrors, or convert full weights inside `forward`.
-- Does not open, replace, rename, or write any ComfyUI source file.
+## Server smoke test
 
-This runtime build has been run successfully with the ComfyUI 0.33.2 H3 structure. A future ComfyUI internal refactor may cause an intentional automatic disable instead of an unsafe partial patch.
+Run the same short workflow, seed, model, sampler, steps and offload allocation that produced the error. Confirm sampling finishes, video is non-black and audio is normal. Record total time and peak/resident VRAM. If Sol-Attn is used, retain `fp16_safe=False` (as in the supplied log); do not enable a second H3 precision patch. Sparse-attention combinations and speed remain server-test results.
 
-This is the standalone v0.1.3 runtime profile. Do not stack it with TE-Speed or another H3 runtime/dtype patch; a separately reviewed adapter is required for combined execution.
-
-## Performance evidence
-
-Earlier V100 test case: 0.2 MP, 5 s, 24 fps. Environment: Windows 10, NVIDIA Tesla V100 32 GB, 150 W power limit; the baseline already included TE-Speed.
-
-| Profile | Time | Change from baseline | Result |
-|---|---:|---:|---|
-| TE-Speed baseline | 317 s | — | Passed |
-| **MiniMax H3 V100 mixed-precision profile** | **206 s** | **35.0% faster / 1.54x** | **Passed** |
-
-These figures document the earlier core acceleration profile and are not a universal timing guarantee for every ComfyUI workflow. The v0.1.3 L3 validation reduced resident VRAM without changing the measured inference performance of its comparison build. Actual results depend on workload, backend, offload behavior, power limit, and software build.
-
-For the first A/B test, keep the seed, prompt, model, sampler, steps, resolution, frame count, and attention backend identical. Disable unrelated TeaCache, SageAttention, compilation, global FP16, and FP16-accumulation changes; discard one warm-up run and record at least three measured runs. Stop at the first black frame, NaN, audio defect, or error.
-
-## Legacy source patcher
-
-The pre-0.1.2 source-modifying package is preserved under [`legacy_patcher/`](legacy_patcher/). It contains:
-
-- guarded origin and TE-Speed BAT/Python installers;
-- guarded restore scripts and exact adjacent-backup handling;
-- origin/TE structure detection, AST validation, idempotence, and SHA-256 checks;
-- complete V100 source snapshots for development and manual porting;
-- its own manifest and provenance notice.
-
-The Custom Node is recommended for normal use. Use the legacy patcher only when you intentionally need a modified `model.py`, a TE `block_loop` source conversion, recovery from an earlier patch, or inspectable full source snapshots.
-
-Windows entry points:
-
-```bat
-legacy_patcher\patch_te_v100.bat "D:\ComfyUI\comfy\ldm\minimax\model.py"
-legacy_patcher\patch_h3_origin_v100.bat "D:\ComfyUI\comfy\ldm\minimax\model.py"
-legacy_patcher\restore_te_v100.bat "D:\ComfyUI\comfy\ldm\minimax\model.py"
-legacy_patcher\restore_h3_origin_v100.bat "D:\ComfyUI\comfy\ldm\minimax\model.py"
-```
-
-Python entry points:
+## Local checks / packaging
 
 ```text
-python legacy_patcher/patch_te_v100.py /path/to/ComfyUI
-python legacy_patcher/patch_h3_origin_v100.py /path/to/ComfyUI
+python -B -m unittest discover -s tests -v
+python -B tools/build_release.py
 ```
 
-Development source snapshots:
+The tests execute actual upstream FinalLayer bodies using trace tensors, including normal/PDD routing and schedule handling. PDD head arithmetic is represented by a spy; these are not PyTorch numerical tests or GPU inference. Packaging uses an explicit allowlist, generates hashes, checks ZIP contents and writes a SHA-256 sidecar.
 
-- [`legacy_patcher/sources/origin_v100/model.py`](legacy_patcher/sources/origin_v100/model.py): official/origin loop plus the audio-safe V100 profile.
-- [`legacy_patcher/sources/te_v100/model.py`](legacy_patcher/sources/te_v100/model.py): TE-Speed block-loop hooks plus the same profile.
+## Acknowledgement and license
 
-The supported clean origin source is derived from the ComfyUI implementation containing audio fix [`93cb5edb`](https://github.com/Comfy-Org/ComfyUI/commit/93cb5edb) and has SHA-256 `1c9828ec3d38ac01398e45b1edf8d7db38fcc8148c5eb3ba8fb92b762147d0ce`. See [`legacy_patcher/NOTICE.md`](legacy_patcher/NOTICE.md) for the original patcher evidence and [`NOTICE.md`](NOTICE.md) for the current runtime boundary.
-
-## Acknowledgements
-
-Special thanks to [Amduraznak/minimax-h3-fp16-fix](https://github.com/Amduraznak/minimax-h3-fp16-fix). That project demonstrated that MiniMax H3 acceleration could be delivered cleanly through a ComfyUI Custom Node and inspired the v0.1.2 move away from persistent source edits.
-
-This project keeps its existing, independently tested **FP32 ocean + FP16 hotspot islands** precision strategy; the acknowledgement is specifically for the Custom Node delivery approach. Thanks also to ComfyUI, MiniMax, and the TE-Speed contributors whose work forms the surrounding ecosystem.
-
-## Scope and license
-
-This is a community mixed-precision extension, not an official MiniMax, TE-Speed, ComfyUI, or acknowledged-project release. SPDX license identifier: `GPL-3.0-only`; see [`LICENSE`](LICENSE). The acknowledged project is separately licensed by its author.
+Thanks to ComfyUI, MiniMax and [Amduraznak/minimax-h3-fp16-fix](https://github.com/Amduraznak/minimax-h3-fp16-fix) for the Custom Node delivery pattern and related mixed-precision work. This is an independent community extension. SPDX: `GPL-3.0-only`; see `LICENSE` and `NOTICE.md`.

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -1,139 +1,60 @@
-# MiniMax H3 V100 混合精度 Custom Node v0.1.3
+# MiniMax H3 V100 — Custom Node v0.1.4
 
 [English](README.md) | 简体中文
 
-**v0.1.3 新版优化了推理期间的常驻显存开销，同时保持推理性能不变；目前已在 ComfyUI 0.33.2 上成功运行。**
+0.1.4 修复 `_patched_final_forward() takes 5 positional arguments but 8 were given`，保留独立 L3 的 FP16 存储/计算分支及 FP32 保护。目前完成本地结构、参数传递和精度流回归；**V100 实际推理、画面、音频、速度和显存仍待服务器测试**。
 
-**v0.1.3** 将已经成功的 L3 混合精度方案提升为正式 Custom Node 版本。模型权重在 ComfyUI 加载、预取和卸载期间保持 FP16 常驻，同时为数值敏感的残差、音频和最终输出路径保留 FP32 安全岛。
+## 安装 / 升级
 
-Custom Node 不再改写 `comfy/ldm/minimax/model.py`，不需要修改启动命令，删除一个文件夹并重启即可卸载。此前的 v0.1.2 也曾在 ComfyUI 0.31.1 和 0.32.0 上成功运行。
-
-此前会修改源码的安装器仍完整保存在 [`legacy_patcher/`](legacy_patcher/) 中，用于恢复、开发，以及确实需要源码补丁的场景。
-
-## 推荐：使用 Custom Node
-
-### 安装前
-
-请确保 ComfyUI 的 `comfy/ldm/minimax/model.py` 是干净、未打补丁的版本。如果以前使用过本项目旧版 patcher，请先关闭 ComfyUI，再运行对应的恢复脚本：
-
-```bat
-legacy_patcher\restore_te_v100.bat "D:\ComfyUI\comfy\ldm\minimax\model.py"
-legacy_patcher\restore_h3_origin_v100.bat "D:\ComfyUI\comfy\ldm\minimax\model.py"
-```
-
-为避免加载顺序决定精度行为，运行时扩展会主动拒绝叠加在旧源码补丁或其他 H3 monkey-patch 之上。
-
-### 安装方法
-
-1. 关闭 ComfyUI。
-2. 下载或克隆本仓库。
-3. 将整个仓库文件夹放入 `ComfyUI/custom_nodes/`。关键目录结构如下：
+1. 完全关闭 ComfyUI。
+2. 从 `custom_nodes` 删除旧 H3 补丁目录，包括旧的 `minimax-h3-v100-l3-clean`、`minimax-h3-v100-patch` 或 preview 副本；移除已安装的 `minimax-h3-v100-l3-te` 和 TE-Speed。只留一个 H3 精度补丁。
+3. 将 `minimax-h3-v100-v0.1.4.zip` 解压到实际使用的 `custom_nodes`。你提供的报错对应 `C:\Comfyui\custom_nodes`。正确目录层级为：
 
    ```text
-   ComfyUI/
-   └─ custom_nodes/
-      └─ minimax-h3-v100-patch/
-         ├─ __init__.py
-         ├─ runtime_patch.py
-         ├─ README_zh-CN.md
-         └─ legacy_patcher/
+   custom_nodes/minimax-h3-v100-l3-clean/__init__.py
+   custom_nodes/minimax-h3-v100-l3-clean/runtime_patch.py
    ```
 
-4. 按原来的方式正常启动 ComfyUI。不要为本方案添加 `--fp16-unet`、`--force-fp16` 或其他全局精度参数。
-5. 在启动日志中确认出现：
+4. 正常启动 ComfyUI，无需添加工作流节点或 `--fp16-unet`。ComfyUI 的 `comfy/ldm/minimax/model.py` 应保持官方原版。
+5. 启动日志确认 `v0.1.4 runtime profile installed`；模型加载时确认 `enabled v0.1.4` 及主 DiT block 数量。
 
-   ```text
-   [MiniMax H3 V100] v0.1.3 runtime profile installed: v0.1.3: native FP16 storage/branches + FP32 safety islands
-   [MiniMax H3 V100] registered native FP16 H3 loading for CUDA capability 7.0 (Volta/V100); no --fp16-unet flag is required
-   ```
+本包不含 TE 适配版或旧式源码修改器。如果之前手动修改过 ComfyUI 源码，先恢复当前 ComfyUI 版本对应的官方文件。仅安装过 Custom Node 的情况下，卸载只需删除插件目录并重启。
 
-第一次加载 H3 模型时，日志还会显示已启用的主 DiT Block 数量。本扩展不会在工作流界面增加节点，现有 MiniMax H3 工作流照常使用。
+## 本次修复
 
-### 更新与卸载
+官方 `v0.34.5` 标签版仍是四输入 FinalLayer 接口。你的报告标注 `0.34.0`，但实际 H3 源码已调用新增 `sigma`、`sample_sigmas`、`shifts` 的七输入接口，因此按实际源码接口兼容，不单凭版本号判断。
 
-- 更新：关闭 ComfyUI，用新版本替换本仓库文件夹，然后重启。
-- 卸载：从 `custom_nodes` 删除本仓库文件夹并重启。如果只使用过 Custom Node 模式，不需要恢复任何 ComfyUI 源码备份。
+- FinalLayer 将隐藏状态和时间嵌入转成 FP32 后，完整传递所有位置参数、关键字参数给原生实现。
+- 保留上游调制行处理、PDD 输出头选择、采样时间表检查和音视频各自的 shift 权重逻辑。
+- 适配新版 DiT block 的 `attention` 参数；旧版调用未提供该参数时，不向旧实现额外传入。
+- Attention/MLP/DiT 的重写接口出现未知参数时，在注册 FP16 之前停止安装，避免不完整覆盖。
 
-## v0.1.3 显存与精度分配
+核对源码：[ComfyUI v0.34.5](https://github.com/Comfy-Org/ComfyUI/blob/v0.34.5/comfy/ldm/minimax/model.py) 和 [PDD 主线固定提交 15eb748b](https://github.com/Comfy-Org/ComfyUI/blob/15eb748b3ec5f8a0a2d470b7fb280e2d7579f916/comfy/ldm/minimax/model.py)。完整哈希见 `tests/fixtures/PROVENANCE.json`。
 
-- ComfyUI 加载、预取和卸载期间使用原生 FP16 模型存储。
-- 50 个主 DiT Block 的 QKV、Q/K RMSNorm、RoPE 及文本/视频 Attention 使用 FP16。
-- 目标/参考音频 Attention 使用 FP32 重算。
-- Attention 输出投影使用 `/64 → FP16 out_proj → FP32 ×64`。
-- MLP 使用 FP16 `fc1`、FP32 SwiGLU，以及 `/256 → FP16 fc2 → FP32 ×256`。
-- 主残差、Block Norm、AdaLN/调制、condition 输入、Token Refiner、最终 AdaLN 和视频/音频输出头保持 FP32。
+## 精度策略
 
-仍然不启用全 FP16 final heads。v0.1.3 通过原生 FP16 常驻降低显存，而不是在 `forward` 内反复转换完整权重，也不会跨 Block 保留完整 FP32 权重镜像。
+- ComfyUI 原生 FP16 权重加载、预取及卸载。
+- 主 DiT 的 attention/MLP 分支使用 FP16；目标及参考音频 attention 使用 FP32 重算。
+- Attention 输出：`/64 → FP16 投影 → FP32 ×64`。
+- MLP：FP16 `fc1`、FP32 SwiGLU、`/256 → FP16 fc2 → FP32 ×256`。
+- 残差、归一化/调制、condition 输入、Token Refiner 和最终输出头保留 FP32 保护。
+- 保留 CUDA 7.0 设备限制、重复补丁检查；不使用临时 `weight.data` 转换。
 
-## 运行时安全机制
+Attention 和 MLP 计算函数的 AST 哈希与 0.1.3 一致。此前 0.1.3 文档记录了 ComfyUI 0.33.2 实测通过和驻留显存下降；这些历史结果不能代替 0.1.4 的服务器实测。
 
-- 加载前检查当前 `Attention`、`DiTBlock`、`MLP`、`MiniMaxH3Model` 和 `PackedLayout` 结构。
-- 检测到旧的源码级 V100 patch 或其他扩展已经接管关键 H3 方法时拒绝叠加。
-- 如果其他扩展在本项目之后加载，也会再次检查，并让新模型实例保持未修改状态。
-- 重复加载具有幂等性。
-- 音频行信息缺失或无效时，该次调用安全回退到完整 FP32 Attention。
-- 检测到其他扩展或源码补丁已经暴露冲突的 H3 FP16 路径时拒绝叠加。
-- 不修改 `weight.data`，不缓存完整 FP32 权重镜像，也不在 `forward` 内转换完整权重。
-- 不会打开、替换、重命名或写入任何 ComfyUI 源码文件。
+## 服务器测试
 
-本版本已经在 ComfyUI 0.33.2 的 H3 结构上成功运行。如果未来 ComfyUI 重构内部实现，本扩展会优先自动禁用，而不是执行不完整的危险补丁。
+先复跑这次报错的短工作流，固定模型、种子、采样器、步数、分辨率及 offload 分配。确认采样完成、画面不黑、音频正常，再记录耗时及显存。如果继续使用 Sol-Attn，保持报告中的 `fp16_safe=False`，避免叠加另一套 H3 精度补丁。稀疏注意力组合效果和速度以服务器结果为准。
 
-这是独立运行的 v0.1.3 正式版。不要与 TE-Speed 或其他 H3 runtime/dtype patch 叠加；组合运行需要单独审核的适配版本。
-
-## 性能依据
-
-早期 V100 测试用例：0.2 百万像素、5 秒、24 fps。环境：Windows 10、NVIDIA Tesla V100 32 GB、150 W 功率限制；基线已经包含 TE-Speed。
-
-| 方案 | 耗时 | 相对基线变化 | 结果 |
-|---|---:|---:|---|
-| TE-Speed 基线 | 317 秒 | — | 成功 |
-| **MiniMax H3 V100 混合精度方案** | **206 秒** | **加速 35.0% / 1.54 倍** | **成功** |
-
-这些数字用于记录早期核心加速方案，不代表所有 ComfyUI 工作流都能获得相同耗时。v0.1.3 的 L3 验证降低了推理期间常驻显存，同时没有改变其对照版本的实测推理性能。实际结果取决于工作负载、Attention 后端、卸载方式、功率限制和软件构建。
-
-第一次 A/B 测试应固定随机种子、提示词、模型、采样器、步数、分辨率、帧数和 Attention 后端，并关闭无关的 TeaCache、SageAttention、编译、全局 FP16 和 FP16 accumulation 改动。丢弃一次预热并至少记录三次正式运行；遇到第一处黑屏、NaN、音频异常或报错时立即停止继续扩大精度边界。
-
-## Legacy 源码 patcher
-
-0.1.2 之前会修改源码的整套工具已收纳到 [`legacy_patcher/`](legacy_patcher/) 中，其中包括：
-
-- 带安全检查的 origin/TE-Speed BAT 和 Python 安装器；
-- 带验证的恢复脚本及精确相邻备份机制；
-- origin/TE 结构识别、AST 检查、幂等性和 SHA-256 校验；
-- 用于开发和手动移植的完整 V100 源码快照；
-- 独立的 manifest 和原始验证来源说明。
-
-普通用户应优先使用 Custom Node。只有在明确需要修改 `model.py`、安装 TE `block_loop` 源码钩子、恢复旧补丁，或检查完整源码快照时，才建议使用 legacy patcher。
-
-Windows 入口：
-
-```bat
-legacy_patcher\patch_te_v100.bat "D:\ComfyUI\comfy\ldm\minimax\model.py"
-legacy_patcher\patch_h3_origin_v100.bat "D:\ComfyUI\comfy\ldm\minimax\model.py"
-legacy_patcher\restore_te_v100.bat "D:\ComfyUI\comfy\ldm\minimax\model.py"
-legacy_patcher\restore_h3_origin_v100.bat "D:\ComfyUI\comfy\ldm\minimax\model.py"
-```
-
-Python 入口：
+## 本地验证与打包
 
 ```text
-python legacy_patcher/patch_te_v100.py /path/to/ComfyUI
-python legacy_patcher/patch_h3_origin_v100.py /path/to/ComfyUI
+python -B -m unittest discover -s tests -v
+python -B tools/build_release.py
 ```
 
-完整开发源码：
+回归测试用 trace tensor 执行真实上游 FinalLayer 函数体，覆盖普通/PDD 分支、参数传递及采样表检查；PDD 输出头算术使用调用记录替身，因此不等同于 PyTorch 数值验证或 GPU 推理。打包脚本使用明确文件清单，生成 manifest，核对 ZIP 内容并输出 SHA-256 校验文件。
 
-- [`legacy_patcher/sources/origin_v100/model.py`](legacy_patcher/sources/origin_v100/model.py)：官方/origin Block Loop 加音频安全 V100 方案。
-- [`legacy_patcher/sources/te_v100/model.py`](legacy_patcher/sources/te_v100/model.py)：TE-Speed Block Loop 钩子加相同精度方案。
+## 致谢与许可
 
-受支持的干净 origin 源码基于包含 ComfyUI audio 修复 [`93cb5edb`](https://github.com/Comfy-Org/ComfyUI/commit/93cb5edb) 的实现，其 SHA-256 为 `1c9828ec3d38ac01398e45b1edf8d7db38fcc8148c5eb3ba8fb92b762147d0ce`。旧 patcher 的验证证据见 [`legacy_patcher/NOTICE.md`](legacy_patcher/NOTICE.md)，当前运行时边界见 [`NOTICE.md`](NOTICE.md)。
-
-## 致谢
-
-特别感谢 [Amduraznak/minimax-h3-fp16-fix](https://github.com/Amduraznak/minimax-h3-fp16-fix)。这个项目展示了通过 ComfyUI Custom Node 干净地交付 MiniMax H3 加速的方法，并启发本项目在 0.1.2 中从持久修改源码转向运行时加载。
-
-本项目继续采用自己此前独立测试的“**FP32 海洋 + FP16 热点岛屿**”精度策略；这里的致谢主要针对 Custom Node 的交付思路。同时感谢 ComfyUI、MiniMax 和 TE-Speed 贡献者提供的基础生态。
-
-## 项目范围与许可
-
-这是社区制作的混合精度扩展，不是 MiniMax、TE-Speed、ComfyUI 或上述致谢项目的官方版本。许可证 SPDX 标识符为 `GPL-3.0-only`，完整条款见 [`LICENSE`](LICENSE)；致谢项目使用其作者单独声明的许可证。
+感谢 ComfyUI、MiniMax 以及 [Amduraznak/minimax-h3-fp16-fix](https://github.com/Amduraznak/minimax-h3-fp16-fix) 的 Custom Node 交付模式及相关混合精度工作。本项目为独立社区扩展。许可：`GPL-3.0-only`，见 `LICENSE` 和 `NOTICE.md`。

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
-"""ComfyUI entry point for the MiniMax H3 V100 v0.1.3 profile."""
+"""ComfyUI entry point for the MiniMax H3 V100 v0.1.4 profile."""
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"
 
 from .runtime_patch import PATCH_STATUS, install_patch
 

--- a/runtime_patch.py
+++ b/runtime_patch.py
@@ -1,4 +1,4 @@
-"""MiniMax H3 V100 v0.1.3 mixed-precision profile for ComfyUI.
+"""MiniMax H3 V100 v0.1.4 mixed-precision profile for ComfyUI.
 
 This release registers FP16 as a supported inference dtype for MiniMax H3
 before the model is instantiated. Main-block weights are therefore created,
@@ -28,27 +28,27 @@ import comfy.supported_models as supported_models
 from comfy.ldm.modules.attention import attention_pytorch, optimized_attention
 
 
-PROFILE_ID = "minimax-h3-v100-v013-native-fp16-branches"
-PROFILE_LABEL = "v0.1.3: native FP16 storage/branches + FP32 safety islands"
-PACKAGE_VERSION = "0.1.3"
+PROFILE_ID = "minimax-h3-v100-v014-native-fp16-branches"
+PROFILE_LABEL = "v0.1.4: native FP16 storage/branches + FP32 safety islands"
+PACKAGE_VERSION = "0.1.4"
 OUT_PROJ_SCALE = 64.0
 MLP_FC2_SCALE = 256.0
 
 _MODULE_PATCH_MARKER = "_minimax_h3_v100_custom_node_profile"
 _SUPPORTED_MODEL_PATCH_MARKER = "_minimax_h3_v100_supported_dtype_profile"
-_BLOCK_ENABLE_FLAG = "_minimax_h3_v100_v013_fp32_residual"
-_ATTENTION_ENABLE_FLAG = "_minimax_h3_v100_v013_audio_safe_attention"
-_MLP_ENABLE_FLAG = "_minimax_h3_v100_v013_scaled_mlp"
-_FINAL_ENABLE_FLAG = "_minimax_h3_v100_v013_fp32_final"
-_CONDITION_WRAPPED_FLAG = "_minimax_h3_v100_v013_fp32_condition"
+_BLOCK_ENABLE_FLAG = "_minimax_h3_v100_v014_fp32_residual"
+_ATTENTION_ENABLE_FLAG = "_minimax_h3_v100_v014_audio_safe_attention"
+_MLP_ENABLE_FLAG = "_minimax_h3_v100_v014_scaled_mlp"
+_FINAL_ENABLE_FLAG = "_minimax_h3_v100_v014_fp32_final"
+_CONDITION_WRAPPED_FLAG = "_minimax_h3_v100_v014_fp32_condition"
 _LAYOUT_RANGES_ATTR = "_minimax_h3_v100_fp32_audio_ranges"
 _OPTIONS_RANGES_KEY = "minimax_h3_fp32_audio_ranges"
 
 _AUDIO_RANGES: contextvars.ContextVar[tuple[tuple[int, int], ...]] = contextvars.ContextVar(
-    "minimax_h3_v100_v013_audio_ranges", default=()
+    "minimax_h3_v100_v014_audio_ranges", default=()
 )
 _CAPTURE_LAYOUT: contextvars.ContextVar[bool] = contextvars.ContextVar(
-    "minimax_h3_v100_v013_capture_layout", default=False
+    "minimax_h3_v100_v014_capture_layout", default=False
 )
 
 _ORIGINAL_SUPPORTED_DTYPES = None
@@ -140,6 +140,16 @@ def _validate_runtime_shape() -> tuple[bool, str]:
         return False, "unsupported MLP.forward signature"
     if not _signature_has(final_forward, ("self", "x", "t_emb", "video_seg", "audio_seg")):
         return False, "unsupported FinalLayer.forward signature"
+    # These methods are reimplemented, unlike the delegated FinalLayer. Reject
+    # added parameters rather than silently bypassing a new upstream feature.
+    for label, function, allowed in (
+        ("Attention.forward", attention_forward, {"self", "x", "rope_freqs", "transformer_options"}),
+        ("MLP.forward", mlp_forward, {"self", "x"}),
+        ("DiTBlock.forward", block_forward,
+         {"self", "x", "t_emb", "mod_segments", "rope_freqs", "transformer_options", "attention"}),
+    ):
+        if not set(inspect.signature(function).parameters).issubset(allowed):
+            return False, f"unsupported {label} signature; unknown parameters"
     if not _signature_has(model_init, ("self", "dtype", "operations")):
         return False, "unsupported MiniMaxH3Model.__init__ signature"
     if not _signature_has(model_forward, ("self", "x", "context", "transformer_options", "minimax_payload")):
@@ -188,7 +198,7 @@ def _validate_runtime_shape() -> tuple[bool, str]:
     if torch.bfloat16 not in current_dtypes or torch.float32 not in current_dtypes:
         return False, "unsupported MiniMaxH3 inference-dtype declaration"
 
-    return True, "supported ComfyUI 0.33.2 MiniMax H3 structure"
+    return True, "supported MiniMax H3 structure (legacy/PDD final forwarding)"
 
 
 def _ranges_from_layout(layout: Any) -> tuple[tuple[int, int], ...]:
@@ -305,13 +315,13 @@ def _patched_model_init(self, *args, **kwargs):
     ):
         _warn_once(
             "late-runtime-conflict",
-            "another H3 runtime extension loaded after v0.1.3; new H3 instances stay unmodified",
+            "another H3 runtime extension loaded after v0.1.4; new H3 instances stay unmodified",
         )
         return
     if getattr(self, "dtype", None) != torch.float16:
         _warn_once(
             "model-not-native-fp16",
-            f"H3 was instantiated as {getattr(self, 'dtype', None)}, not FP16; v0.1.3 is inactive for this instance",
+            f"H3 was instantiated as {getattr(self, 'dtype', None)}, not FP16; v0.1.4 is inactive for this instance",
         )
         return
 
@@ -319,20 +329,20 @@ def _patched_model_init(self, *args, **kwargs):
     if not blocks or not all(_block_shape_supported(block) for block in blocks):
         _warn_once(
             "unsupported-block",
-            "the main H3 block structure is unfamiliar; v0.1.3 is inactive for this instance",
+            "the main H3 block structure is unfamiliar; v0.1.4 is inactive for this instance",
         )
         return
     final_layer = getattr(self, "final_layer", None)
     if final_layer is None or not _final_shape_supported(final_layer):
         _warn_once(
             "unsupported-final-layer",
-            "the H3 FinalLayer structure is unfamiliar; v0.1.3 is inactive for this instance",
+            "the H3 FinalLayer structure is unfamiliar; v0.1.4 is inactive for this instance",
         )
         return
     if not _wrap_condition_projection(self):
         _warn_once(
             "missing-condition-proj",
-            "condition_proj could not be wrapped for FP32 overflow safety; v0.1.3 is inactive for this instance",
+            "condition_proj could not be wrapped for FP32 overflow safety; v0.1.4 is inactive for this instance",
         )
         return
 
@@ -454,23 +464,21 @@ def _patched_mlp_forward(self, x):
     return projected.to(dtype=torch.float32).mul_(MLP_FC2_SCALE)
 
 
-def _patched_final_forward(self, x, t_emb, video_seg, audio_seg):
+def _patched_final_forward(self, x, t_emb, video_seg, audio_seg, *args, **kwargs):
+    """Keep FP32 safety while retaining upstream modulation and PDD head logic.
+
+    Older ComfyUI calls have four inputs; PDD builds also pass sigma,
+    sample_sigmas and shifts. Delegate both forms without discarding arguments.
+    """
     enabled = (
         getattr(self, _FINAL_ENABLE_FLAG, False)
         and getattr(getattr(x, "device", None), "type", None) == "cuda"
         and not model_management.in_training
     )
-    if not enabled:
-        return _ORIGINAL_FINAL_FORWARD(self, x, t_emb, video_seg, audio_seg)
-
-    x = x.to(dtype=torch.float32)
-    t_emb = t_emb.to(dtype=torch.float32)
-    shift, scale = self.adaln_proj(t_emb)
-    va, vb, vrow = video_seg
-    aa, ab, arow = audio_seg
-    hv = self.norm(x[va:vb]) * (1.0 + scale[vrow]) + shift[vrow]
-    ha = self.norm(x[aa:ab]) * (1.0 + scale[arow]) + shift[arow]
-    return self.video_out(hv.to(dtype=torch.float32)), self.audio_out(ha.to(dtype=torch.float32))
+    if enabled:
+        x = x.to(dtype=torch.float32)
+        t_emb = t_emb.to(dtype=torch.float32)
+    return _ORIGINAL_FINAL_FORWARD(self, x, t_emb, video_seg, audio_seg, *args, **kwargs)
 
 
 def _patched_block_forward(
@@ -480,6 +488,7 @@ def _patched_block_forward(
     mod_segments,
     rope_freqs,
     transformer_options={},
+    attention=None,
 ):
     enabled = (
         getattr(self, _BLOCK_ENABLE_FLAG, False)
@@ -487,6 +496,8 @@ def _patched_block_forward(
         and not model_management.in_training
     )
     if not enabled:
+        # Do not send the new keyword to older ComfyUI implementations.
+        extra = {} if attention is None else {"attention": attention}
         return _ORIGINAL_BLOCK_FORWARD(
             self,
             x,
@@ -494,6 +505,7 @@ def _patched_block_forward(
             mod_segments,
             rope_freqs,
             transformer_options=transformer_options,
+            **extra,
         )
 
     if x.dtype != torch.float32:
@@ -503,7 +515,8 @@ def _patched_block_forward(
     h = mm._mod_scale_shift(self.norm1(x), shift_msa, scale_msa, mod_segments).to(
         dtype=torch.float16
     )
-    attention_out = self.attn(
+    attention_forward = self.attn if attention is None else attention
+    attention_out = attention_forward(
         h,
         rope_freqs=rope_freqs,
         transformer_options=transformer_options,

--- a/tests/fixtures/PROVENANCE.json
+++ b/tests/fixtures/PROVENANCE.json
@@ -1,0 +1,17 @@
+{
+  "retrieved_date": "2026-09-06",
+  "license": "GPL-3.0-only",
+  "purpose": "Unmodified upstream source fixtures; never installed over ComfyUI",
+  "files": {
+    "model_v0345.py": {
+      "url": "https://raw.githubusercontent.com/Comfy-Org/ComfyUI/v0.34.5/comfy/ldm/minimax/model.py",
+      "ref": "v0.34.5",
+      "sha256": "b3f51bfd5c44962c3bbe09c3e16e34698a286c5279e050ea6c3defbb8434c34e"
+    },
+    "model_pdd.py": {
+      "url": "https://raw.githubusercontent.com/Comfy-Org/ComfyUI/15eb748b3ec5f8a0a2d470b7fb280e2d7579f916/comfy/ldm/minimax/model.py",
+      "ref": "15eb748b3ec5f8a0a2d470b7fb280e2d7579f916",
+      "sha256": "648182d0368047ea77864494b2675ca3f09d0fc2c857f53bb989adff947e17c6"
+    }
+  }
+}

--- a/tests/fixtures/model_pdd.py
+++ b/tests/fixtures/model_pdd.py
@@ -1,0 +1,778 @@
+"""MiniMax H3 audio-video DiT.
+
+Single-stream packed-token transformer denoising video (24ch, patch 1x2x2) and
+stereo audio (32ch, 40 Hz) latents jointly, conditioned on Qwen3-VL layer-50 hidden states.
+The packed sequence is:
+[text | cond rows | audio | video] for t2va/fl2va
+[text | reference blocks | audio | video] for ref2va
+
+Timestep domain: the model receives the *video* sigma from the sampler and
+derives per-token timesteps t = 1 - sigma internally; the audio stream runs on
+its own shifted schedule (sigma_shift video 12.0 / audio 3.0), mapped from the
+video sigma in closed form. The sampler carries the audio latent scaled onto the
+video schedule (ModelSamplingAV); forward() undoes that scale and converts the
+velocity back, so _forward only ever sees the stream's own latent.
+"""
+
+import math
+
+import torch
+import torch.nn as nn
+
+import comfy.ldm.common_dit
+import comfy.model_management
+import comfy.model_prefetch
+import comfy.ops
+import comfy.patcher_extension
+import comfy.quant_ops
+from comfy.ldm.modules.attention import AttentionTensorContainer, optimized_attention
+
+FRAME_PER_TOKEN = (1, 4, 4, 4, 4)
+FRAME_RESCALE = 5.0 / 3.0
+VISUAL_COND_TIMESTEP = 0.999
+AUDIO_COND_TIMESTEP = 1.0
+
+
+def time_shift_sigma(sigma, from_shift, to_shift):
+    # invert sigma = s*b/(1+(s-1)*b) to the base grid, re-apply the other shift
+    base = sigma / (from_shift + sigma * (1.0 - from_shift))
+    return to_shift * base / (1.0 + (to_shift - 1.0) * base)
+
+
+def patchify_video(latent, patch_size=(1, 2, 2)):
+    # [B, C, T, H, W] -> [B*t*h*w, C*pt*ph*pw]
+    b, c, t_full, h_full, w_full = latent.shape
+    pt, ph, pw = patch_size
+    t, h, w = t_full // pt, h_full // ph, w_full // pw
+    x = latent.reshape(b, c, t, pt, h, ph, w, pw)
+    x = torch.einsum("nctrhpwq->nthwcrpq", x)
+    return x.reshape(b * t * h * w, c * pt * ph * pw)
+
+
+def unpatchify_video(rows, t, h, w, c=24, patch_size=(1, 2, 2)):
+    pt, ph, pw = patch_size
+    x = rows.reshape(-1, t, h, w, c, pt, ph, pw)
+    x = torch.einsum("nthwcrpq->nctrhpwq", x)
+    return x.reshape(-1, c, t * pt, h * ph, w * pw)
+
+
+def pack_audio(latent):
+    # [B, C=32, ch=2, T] -> [ch*T, 32] channel-major (ch0 t0..T-1, ch1 t0..T-1)
+    b, c, ch, t = latent.shape
+    return latent[0].permute(1, 2, 0).reshape(ch * t, c)
+
+
+def unpack_audio(rows, ch=2):
+    t = rows.shape[0] // ch
+    return rows.reshape(ch, t, rows.shape[-1]).permute(2, 0, 1).unsqueeze(0)
+
+
+def _axis_from_sqrt_area(dim, patch, sqrt_area):
+    # linspace((1 - ratio) / 2, (1 + ratio) / 2, dim // patch, endpoint=False) * 32
+    ratio = dim / sqrt_area
+    n = dim // patch
+    return (torch.arange(n, dtype=torch.float64) * (ratio / n) + (1.0 - ratio) / 2.0) * 32.0
+
+
+def mask_row_values(mask, latent_t, lat_h, lat_w):
+    # [T, H, W] denoise mask (1 = generate) -> per-2x2-patch-row float in [0, 1],
+    # None when every row fully generates
+    m = torch.nn.functional.pad(mask, (0, lat_w - mask.shape[-1], 0, lat_h - mask.shape[-2]), mode="replicate")
+    m = m.reshape(latent_t, lat_h // 2, 2, lat_w // 2, 2).amax(dim=(2, 4))
+    values = m.reshape(-1)
+    if bool((values >= 1.0 - 1e-3).all()):
+        return None
+    return values
+
+
+def _frame_grid(h, w):
+    # area-normalized (h, w) coordinates of one latent frame's 2x2-patch rows
+    area = math.sqrt(h * w)
+    hh, ww = torch.meshgrid(_axis_from_sqrt_area(h, 2, area), _axis_from_sqrt_area(w, 2, area), indexing="ij")
+    return torch.stack([hh.reshape(-1), ww.reshape(-1)], dim=-1), _axis_from_sqrt_area(w, 2, area)
+
+
+def _video_t_spans(n):
+    return [FRAME_RESCALE * FRAME_PER_TOKEN[k % 5] for k in range(n)]
+
+
+def _video_t_grid(n, origin):
+    # origin + exclusive cumsum
+    spans = torch.tensor(_video_t_spans(n), dtype=torch.float64)
+    return float(origin) + torch.cat([torch.zeros(1, dtype=torch.float64), spans[:-1].cumsum(0)])
+
+
+def _ref_t_span(blk):
+    # time-axis span a reference block occupies ahead of the target streams
+    kind = blk["kind"]
+    if kind == "image":
+        return 1.0
+    if kind == "audio":
+        return float(blk["ref_audio_t"])
+    if kind in ("video", "video_audio"):
+        return max(float(blk["ref_audio_t"]), sum(_video_t_spans(blk["latent_t"])))
+    return 0.0
+
+
+def _audio_grid(cursor, t, w_low, w_high):
+    # channel-major stereo rows: t advances per latent frame, w pinned to the grid extremes per stereo channel, h stays 0
+    g = torch.zeros(t * 2, 3, dtype=torch.float64)
+    g[:, 0] = (cursor + torch.arange(t, dtype=torch.float64)).repeat(2)
+    g[:t, 2] = w_low
+    g[t:, 2] = w_high
+    return g
+
+
+def _video_grid(vt, frame, cursor):
+    g = torch.empty(vt, frame.shape[0], 3, dtype=torch.float64)
+    g[:, :, 0] = _video_t_grid(vt, cursor)[:, None]
+    g[:, :, 1:] = frame[None]
+    return g.reshape(-1, 3)
+
+
+class TimeEmbedder(nn.Module):
+    def __init__(self, freq_dim, hidden, out, dtype=None, device=None, operations=None):
+        super().__init__()
+        self.freq_dim = freq_dim
+        self.proj_in = operations.Linear(freq_dim, hidden, bias=True, dtype=dtype, device=device)
+        self.proj_out = operations.Linear(hidden, out, bias=True, dtype=dtype, device=device)
+
+    def forward(self, t):
+        # t: [M] in [0, 1]; fp32 throughout, cos before sin
+        half = self.freq_dim // 2
+        freqs = torch.exp(-math.log(10000.0) * torch.arange(half, dtype=torch.float32, device=t.device) / half)
+        args = t.to(torch.float32)[:, None] * freqs[None]
+        emb = torch.cat([torch.cos(args), torch.sin(args)], dim=-1)
+        return self.proj_out(nn.functional.silu(self.proj_in(emb)))
+
+
+def rope_rotation_table(angles, dtype):
+    """[S, rot_dim] pair angles -> [1, S, 1, rot_dim/2, 2, 2] rotation matrices."""
+    half = angles.shape[-1] // 2
+    ang = angles[:, :half]  # duplicated halves: [:, :half] == [:, half:]
+    c, s = torch.cos(ang), torch.sin(ang)
+    table = torch.stack([c, -s, s, c], dim=-1).reshape(1, angles.shape[0], 1, half, 2, 2)
+    return table.to(dtype)
+
+
+class Attention(nn.Module):
+    def __init__(self, hidden, heads, head_dim, eps, gate_compress=False, dtype=None, device=None, operations=None):
+        super().__init__()
+        self.heads = heads
+        self.head_dim = head_dim
+        inner = heads * head_dim
+        self.qkv_proj = operations.Linear(hidden, inner * 3, bias=False, dtype=dtype, device=device)
+        self.q_norm = operations.RMSNorm(head_dim, eps=eps, dtype=dtype, device=device)
+        self.k_norm = operations.RMSNorm(head_dim, eps=eps, dtype=dtype, device=device)
+        self.out_proj = operations.Linear(inner, hidden, bias=False, dtype=dtype, device=device)
+        self.to_gate_compress = None
+        if gate_compress:
+            # VSA gate, unused by the dense forward; consumed by sparse attention patches
+            self.to_gate_compress = operations.Linear(hidden, inner, bias=False, dtype=dtype, device=device)
+
+    def forward(self, x, rope_freqs=None, transformer_options={}):
+        s = x.shape[0]
+        q, k, v = self.qkv_proj(x).split(self.heads * self.head_dim, dim=-1)
+        v = v.view(s, self.heads, self.head_dim)
+        if rope_freqs is not None:
+            # fused per-head RMSNorm + partial split-half rope, in place on the qkv buffer
+            q = q.view(1, s, self.heads, self.head_dim)
+            k = k.view(1, s, self.heads, self.head_dim)
+            qw = comfy.model_management.cast_to(self.q_norm.weight, device=x.device)
+            kw = comfy.model_management.cast_to(self.k_norm.weight, device=x.device)
+            rot = rope_freqs.shape[-3] * 2
+            if comfy.model_management.in_training:
+                q, k = comfy.quant_ops.ck.rms_rope_split_half(
+                    q, k, rope_freqs, qw, kw, epsilon=self.q_norm.eps, rot_dim=rot)
+            else:
+                comfy.quant_ops.ck.rms_rope_split_half_(
+                    q, k, rope_freqs, qw, kw, epsilon=self.q_norm.eps, rot_dim=rot)
+            q = q[0]
+            k = k[0]
+        else:
+            q = self.q_norm(q.view(s, self.heads, self.head_dim))
+            k = self.k_norm(k.view(s, self.heads, self.head_dim))
+
+        q = AttentionTensorContainer(q.transpose(0, 1).unsqueeze(0))
+        k = AttentionTensorContainer(k.transpose(0, 1).unsqueeze(0))
+        v = AttentionTensorContainer(v.transpose(0, 1).unsqueeze(0))
+        out = optimized_attention(q, k, v, self.heads, mask=None, skip_reshape=True, transformer_options=transformer_options)
+        return self.out_proj(out.squeeze(0))
+
+
+class MLP(nn.Module):
+    def __init__(self, hidden, ffn, dtype=None, device=None, operations=None):
+        super().__init__()
+        self.fc1 = operations.Linear(hidden, ffn * 2, bias=False, dtype=dtype, device=device)
+        self.fc2 = operations.Linear(ffn, hidden, bias=False, dtype=dtype, device=device)
+
+    def forward(self, x):
+        return comfy.ops.linear_input_act(self.fc2, self.fc1(x), "swiglu")
+
+
+class AdalnProj(nn.Module):
+    def __init__(self, t_dim, hidden, expand, modalities, apply_silu=True,
+                 dtype=None, device=None, operations=None):
+        super().__init__()
+        self.expand = expand
+        self.modalities = modalities
+        self.hidden = hidden
+        self.apply_silu = apply_silu
+        self.linear = operations.Linear(t_dim, expand * hidden * modalities, bias=True, dtype=dtype, device=device)
+
+    def forward(self, t_emb):
+        # [M, t_dim] -> expand tensors of [M*modalities, hidden]
+        x = self.linear(nn.functional.silu(t_emb) if self.apply_silu else t_emb)
+        x = x.view(x.shape[0] * self.modalities, self.expand * self.hidden)
+        return x.chunk(self.expand, dim=-1)
+
+
+def _mod_row(vecs, row, dtype):
+    # row is a mod-row index, or a per-token LongTensor of mod-row indices
+    return vecs[row].to(dtype)
+
+
+def _mod_scale_shift(h, shift, scale, segments):
+    # segments: [(start, stop, mod_row)] covering h contiguously.
+    for a, b, row in segments:
+        h[a:b].mul_(1.0 + _mod_row(scale, row, h.dtype)).add_(_mod_row(shift, row, h.dtype))
+    return h
+
+
+def _mod_gate(x, gate, other, segments):
+    # other is the fresh attn/mlp output: accumulate the gated residual into the stream in place, one fused kernel per segment
+    for a, b, row in segments:
+        x[a:b].addcmul_(other[a:b], _mod_row(gate, row, x.dtype))
+    return x
+
+
+class RefinerBlock(nn.Module):
+    def __init__(self, hidden, heads, head_dim, ffn, eps, qk_eps, dtype=None, device=None, operations=None):
+        super().__init__()
+        self.norm1 = operations.RMSNorm(hidden, eps=eps, dtype=dtype, device=device)
+        self.norm2 = operations.RMSNorm(hidden, eps=eps, dtype=dtype, device=device)
+        self.attn = Attention(hidden, heads, head_dim, qk_eps, dtype=dtype, device=device, operations=operations)
+        self.mlp = MLP(hidden, ffn, dtype=dtype, device=device, operations=operations)
+
+    def forward(self, x, transformer_options={}):
+        # attn/mlp outputs are fresh: accumulate residuals in place
+        x = self.attn(self.norm1(x), transformer_options=transformer_options).add_(x)
+        return self.mlp(self.norm2(x)).add_(x)
+
+
+class TokenRefiner(nn.Module):
+    def __init__(self, num_layers, hidden, heads, head_dim, ffn, eps, qk_eps, final_eps,
+                 dtype=None, device=None, operations=None):
+        super().__init__()
+        self.blocks = nn.ModuleList([
+            RefinerBlock(hidden, heads, head_dim, ffn, eps, qk_eps, dtype=dtype, device=device, operations=operations)
+            for _ in range(num_layers)])
+        self.final_norm = operations.RMSNorm(hidden, eps=final_eps, dtype=dtype, device=device)
+
+    def forward(self, x, transformer_options={}):
+        for block in self.blocks:
+            x = block(x, transformer_options=transformer_options)
+        return self.final_norm(x)
+
+
+class DiTBlock(nn.Module):
+    def __init__(self, hidden, heads, head_dim, ffn, t_dim, eps, qk_eps,
+                 apply_silu=True, adaln_dtype=None, gate_compress=False, dtype=None, device=None, operations=None):
+        super().__init__()
+        self.norm1 = operations.RMSNorm(hidden, eps=eps, dtype=dtype, device=device)
+        self.norm2 = operations.RMSNorm(hidden, eps=eps, dtype=dtype, device=device)
+        self.attn = Attention(hidden, heads, head_dim, qk_eps, gate_compress=gate_compress,
+                              dtype=dtype, device=device, operations=operations)
+        self.mlp = MLP(hidden, ffn, dtype=dtype, device=device, operations=operations)
+        self.adaln_proj = AdalnProj(t_dim, hidden, 6, 3, apply_silu=apply_silu,
+                                    dtype=adaln_dtype if adaln_dtype is not None else dtype,
+                                    device=device, operations=operations)
+
+    def forward(self, x, t_emb, mod_segments, rope_freqs, transformer_options={}, attention=None):
+        attention = self.attn if attention is None else attention
+        shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = self.adaln_proj(t_emb)
+        h = _mod_scale_shift(self.norm1(x), shift_msa, scale_msa, mod_segments)
+        x = _mod_gate(x, gate_msa, attention(h, rope_freqs=rope_freqs, transformer_options=transformer_options), mod_segments)
+        h = _mod_scale_shift(self.norm2(x), shift_mlp, scale_mlp, mod_segments)
+        return _mod_gate(x, gate_mlp, self.mlp(h), mod_segments)
+
+
+class FinalLayer(nn.Module):
+    def __init__(self, hidden, t_dim, video_dim, audio_dim, eps, apply_silu=True, adaln_dtype=None,
+                 dtype=None, device=None, operations=None):
+        super().__init__()
+        self.norm = operations.RMSNorm(hidden, eps=eps, dtype=dtype, device=device)
+        self.adaln_proj = AdalnProj(t_dim, hidden, 2, 1, apply_silu=apply_silu,
+                                    dtype=adaln_dtype if adaln_dtype is not None else dtype,
+                                    device=device, operations=operations)
+        # output heads are the checkpoint's fp32 island; norm/adaln are stored at model dtype
+        self.video_out = operations.Linear(hidden, video_dim, bias=True, dtype=torch.float32, device=device)
+        self.audio_out = operations.Linear(hidden, audio_dim, bias=True, dtype=torch.float32, device=device)
+
+    def forward(self, x, t_emb, video_seg, audio_seg, sigma, sample_sigmas, shifts):
+        # video_seg / audio_seg: (start, stop, row) of the target streams, where row
+        # is a mod-row index or a per-token blend (see _mod_row)
+        shift, scale = self.adaln_proj(t_emb)
+
+        def mod(seg):
+            a, b, row = seg
+            return (self.norm(x[a:b]) * (1.0 + _mod_row(scale, row, scale.dtype)) + _mod_row(shift, row, shift.dtype)).to(torch.float32)
+
+        n = self.video_out.weight.shape[0] // self.video_out.out_features
+        if n == 1:
+            return self.video_out(mod(video_seg)), self.audio_out(mod(audio_seg))
+
+        # PDD head bank: row block 0 is a full head, later blocks are offsets from it;
+        # a step consumes the dt-weighted mean of the heads it spans.
+        if sample_sigmas is None:
+            raise ValueError("MiniMax H3 PDD heads need the sampler's sigma schedule")
+        i = int((sample_sigmas - sigma).abs().argmin())
+        sigma_next = sample_sigmas[min(i + 1, sample_sigmas.shape[0] - 1)]
+        start, stop = (round(float(1.0 - time_shift_sigma(s, shifts[0], 1.0)) * n) for s in (sigma, sigma_next))
+        start = min(start, n - 1)
+        stop = max(stop, start + 1)
+        return (_pdd_head(self.video_out, mod(video_seg), n, start, stop, shifts[0]),
+                _pdd_head(self.audio_out, mod(audio_seg), n, start, stop, shifts[1]))
+
+
+def _pdd_head(head, h, n, start, stop, flow_shift):
+    grid = torch.linspace(1.0, 0.0, n + 1, dtype=torch.float64)
+    dt = (1.0 - flow_shift * grid / (1.0 + (flow_shift - 1.0) * grid)).diff()[start:stop]
+    w = (dt / dt.sum()).to(h)
+    with comfy.ops.CastBiasWeightContext(head, h, offloadable=True) as (weight, bias):
+        rows = weight.reshape(n, -1, weight.shape[1])
+        brows = bias.reshape(n, -1)
+        first = max(start, 1)
+        return nn.functional.linear(h, rows[0] + torch.einsum("n,noi->oi", w[first - start:], rows[first:stop]),
+                                    brows[0] + torch.einsum("n,no->o", w[first - start:], brows[first:stop]))
+
+
+class PackedLayout:
+    """Static packed-sequence structure for one shape/conditioning signature."""
+
+    def __init__(self, text_len, latent_t, latent_h, latent_w, audio_t, keyframes=None, refs=None):
+        frame, w_grid = _frame_grid(latent_h, latent_w)
+        frame_rows = frame.shape[0]
+
+        segments = [("text", text_len)]  # (kind, n_rows)
+        g = torch.zeros(text_len, 3, dtype=torch.float64)
+        g[:, 0] = torch.arange(text_len, dtype=torch.float64)
+        pos = [g]  # per segment: [n, 3] float64 (t, h, w)
+
+        img_pos, img_update = [], []
+        audio_pos, audio_update = [], []
+        row = text_len
+
+        target_audio_w = (float(w_grid[0]), float(w_grid[-1]))
+        # refs pack between text and the targets, so the target timeline starts after their spans
+        cursor = float(text_len)
+        for blk in refs or ():
+            cursor += _ref_t_span(blk)
+
+        if keyframes:
+            # fl2va: keyframe cond rows right after text, sharing the target spatial grid;
+            # anchors count from the target timeline origin, FRAME_RESCALE per pixel frame, 1.0 per audio latent frame
+            for kf in keyframes:
+                cond_t = cursor + FRAME_RESCALE * kf["resolved_frame_index"]
+                video_latent = kf.get("latent")
+                if video_latent is not None:
+                    vt = video_latent.shape[2]
+                    n = vt * frame_rows
+                    segments.append(("cond", n))
+                    pos.append(_video_grid(vt, frame, cond_t))
+                    img_pos.append(torch.arange(row, row + n))
+                    img_update.append(torch.zeros(n, dtype=torch.bool))
+                    row += n
+                audio_latent = kf.get("audio_latent")
+                if audio_latent is not None:
+                    rt = audio_latent.shape[-1]
+                    segments.append(("cond_audio", rt * 2))
+                    pos.append(_audio_grid(cond_t, rt, *target_audio_w))
+                    audio_pos.append(torch.arange(row, row + rt * 2))
+                    audio_update.append(torch.zeros(rt * 2, dtype=torch.bool))
+                    row += rt * 2
+
+        if refs:
+            cursor = float(text_len)
+            for blk in refs:
+                kind = blk["kind"]
+                if kind == "image":
+                    r_frame, _ = _frame_grid(blk["latent_h"], blk["latent_w"])
+                    n = r_frame.shape[0]
+                    g = torch.empty(n, 3, dtype=torch.float64)
+                    g[:, 0] = cursor
+                    g[:, 1:] = r_frame
+                    segments.append(("ref_img", n))
+                    pos.append(g)
+                    img_pos.append(torch.arange(row, row + n))
+                    img_update.append(torch.zeros(n, dtype=torch.bool))
+                    row += n
+                    cursor += 1.0
+                elif kind == "audio":
+                    rt = blk["ref_audio_t"]
+                    if rt > 0:
+                        segments.append(("ref_audio", rt * 2))
+                        pos.append(_audio_grid(cursor, rt, *target_audio_w))
+                        audio_pos.append(torch.arange(row, row + rt * 2))
+                        audio_update.append(torch.zeros(rt * 2, dtype=torch.bool))
+                        row += rt * 2
+                    cursor += float(rt)
+                elif kind in ("video", "video_audio"):
+                    # the block's audio rows pack immediately before its video
+                    # rows, both sharing the cursor origin
+                    rt = blk["ref_audio_t"]
+                    vt = blk["latent_t"]
+                    r_frame, r_w_grid = _frame_grid(blk["latent_h"], blk["latent_w"])
+                    if rt > 0:
+                        segments.append(("ref_audio", rt * 2))
+                        pos.append(_audio_grid(cursor, rt, float(r_w_grid[0]), float(r_w_grid[-1])))
+                        audio_pos.append(torch.arange(row, row + rt * 2))
+                        audio_update.append(torch.zeros(rt * 2, dtype=torch.bool))
+                        row += rt * 2
+                    n = vt * r_frame.shape[0]
+                    segments.append(("ref_img", n))
+                    pos.append(_video_grid(vt, r_frame, cursor))
+                    img_pos.append(torch.arange(row, row + n))
+                    img_update.append(torch.zeros(n, dtype=torch.bool))
+                    row += n
+                    cursor += max(float(rt), sum(_video_t_spans(vt)))
+
+        # target audio then target video, always the last two segments
+        segments.append(("audio", audio_t * 2))
+        pos.append(_audio_grid(cursor, audio_t, *target_audio_w))
+        audio_pos.append(torch.arange(row, row + audio_t * 2))
+        audio_update.append(torch.ones(audio_t * 2, dtype=torch.bool))
+        row += audio_t * 2
+
+        n_video = latent_t * frame_rows
+        segments.append(("video", n_video))
+        pos.append(_video_grid(latent_t, frame, cursor))
+        img_pos.append(torch.arange(row, row + n_video))
+        img_update.append(torch.ones(n_video, dtype=torch.bool))
+        row += n_video
+
+        self.seq_len = row
+        self.position_ids = torch.cat(pos)  # [S, 3] float64
+        self.img_pos = torch.cat(img_pos)
+        self.img_update = torch.cat(img_update)
+        self.audio_pos = torch.cat(audio_pos)
+        self.audio_update = torch.cat(audio_update)
+        self.signature = (text_len, latent_t, latent_h, latent_w, audio_t)
+        # contiguous segment table (start, stop, kind)
+        # kinds: text / cond / cond_audio / ref_img / ref_audio / audio / video
+        # the packed sequence is uniform per segment in (modality tag, timestep class),
+        # except the text span (tag runs resolved at forward time from the presentation tags)
+        seg_abs = []
+        off = 0
+        for kind, n in segments:
+            seg_abs.append((off, off + n, kind))
+            off += n
+        self.segments = seg_abs
+
+
+class MiniMaxH3Model(nn.Module):
+    def __init__(self, hidden_size=5376, num_layers=50, token_refiner_num_layers=2,
+                 num_attention_heads=56, attention_head_dim=128, ffn_hidden_size=14336,
+                 latents_dim=24, audio_latents_dim=32, patch_size=(1, 2, 2), text_dim=5120,
+                 timestep_input_dim=256, time_embed_hidden_size=5376, time_embed_dim=2688,
+                 rope_inv_freq_len=16, norm_eps=1e-5, qk_norm_eps=1e-5, final_norm_eps=1e-5,
+                 sigma_shift_video=12.0, sigma_shift_audio=3.0,
+                 adaln_curve_grid=None, gate_compress=False,
+                 image_model=None, dtype=None, device=None, operations=None, **kwargs):
+        super().__init__()
+        self.dtype = dtype
+        self.hidden_size = hidden_size
+        self.patch_size = tuple(patch_size)
+        self.latents_dim = latents_dim
+        self.audio_latents_dim = audio_latents_dim
+        self.sigma_shift_video = sigma_shift_video
+        self.sigma_shift_audio = sigma_shift_audio
+        self.use_adaln_curves = adaln_curve_grid is not None
+        # curve-form checkpoints replace the time embedder and full-width adaln weights with a small shared basis of the time-embedding curve
+        curve = {"apply_silu": not self.use_adaln_curves,
+                 "adaln_dtype": torch.float32 if self.use_adaln_curves else dtype}
+        video_patch_dim = latents_dim * self.patch_size[0] * self.patch_size[1] * self.patch_size[2]
+
+        self.video_patch_proj = operations.Linear(video_patch_dim, hidden_size, bias=True, dtype=torch.float32, device=device)
+        self.audio_patch_proj = operations.Linear(audio_latents_dim, hidden_size, bias=True, dtype=torch.float32, device=device)
+        self.condition_proj = operations.Linear(text_dim, hidden_size, bias=True, dtype=dtype, device=device)
+        if self.use_adaln_curves:
+            self.register_buffer("adaln_t_table", torch.empty(adaln_curve_grid, time_embed_dim, dtype=torch.float32))
+        else:
+            self.time_embedder = TimeEmbedder(timestep_input_dim, time_embed_hidden_size, time_embed_dim,
+                                              dtype=torch.float32, device=device, operations=operations)
+        self.rope = nn.Module()
+        self.rope.register_buffer("inv_freq", torch.empty(rope_inv_freq_len, dtype=torch.float32))
+        self.token_refiner = TokenRefiner(token_refiner_num_layers, hidden_size, num_attention_heads,
+                                          attention_head_dim, ffn_hidden_size, norm_eps, qk_norm_eps,
+                                          final_norm_eps, dtype=dtype, device=device, operations=operations)
+        self.blocks = nn.ModuleList([
+            DiTBlock(hidden_size, num_attention_heads, attention_head_dim, ffn_hidden_size,
+                     time_embed_dim, norm_eps, qk_norm_eps, **curve, gate_compress=gate_compress,
+                     dtype=dtype, device=device, operations=operations)
+            for _ in range(num_layers)])
+        self.final_layer = FinalLayer(hidden_size, time_embed_dim, video_patch_dim, audio_latents_dim,
+                                      final_norm_eps, **curve, dtype=dtype, device=device, operations=operations)
+
+    def preprocess_text_embeds(self, text_states):
+        """[B, L, text_dim] Qwen states -> [B, L, hidden] refined text embeds."""
+        if text_states.shape[-1] == self.hidden_size:
+            return text_states
+        return self.token_refiner(self.condition_proj(text_states[0])).unsqueeze(0)
+
+    def rope_freqs(self, position_ids, device):
+        # [S, 3] float64 -> [S, 96] fp32
+        pos = position_ids.to(torch.float32).to(device)
+        inv = comfy.model_management.cast_to(self.rope.inv_freq, device=device)
+        per_axis = pos.unsqueeze(-1) * inv.view(1, 1, -1)      # [S, 3, 16]
+        t_f, h_f, w_f = per_axis.unbind(dim=1)
+        half = torch.cat((t_f, h_f, w_f), dim=-1)              # [S, 48]
+        return torch.cat((half, half), dim=-1)                 # [S, 96]
+
+    def _cond_video_rows(self, payload, device):
+        """Concatenated visual condition rows (normalized latents -> patchified), with condition noise augmentation."""
+        rows = []
+        aug = payload.get("visual_cond_noise_aug", VISUAL_COND_TIMESTEP)
+        seed = int(payload.get("seed", 0))
+        # every condition intentionally restarts the same RNG stream
+        for z in payload.get("cond_video_latents", []):
+            r = patchify_video(z.to(torch.float32), self.patch_size)
+            if aug < 1.0:
+                gen = torch.Generator("cpu").manual_seed(seed)
+                noise = torch.randn(r.shape, generator=gen, dtype=torch.float32)
+                r = aug * r + (1.0 - aug) * noise.to(r.device)
+            rows.append(r.to(device))
+        return torch.cat(rows, dim=0) if rows else None
+
+    def _cond_audio_rows(self, payload, device):
+        rows = []
+        aug = payload.get("audio_cond_noise_aug", AUDIO_COND_TIMESTEP)
+        seed = int(payload.get("seed", 0)) + 1
+        for z in payload.get("cond_audio_latents", []):
+            r = pack_audio(z.to(torch.float32))
+            if aug < 1.0:
+                gen = torch.Generator("cpu").manual_seed(seed)
+                noise = torch.randn(r.shape, generator=gen, dtype=torch.float32)
+                r = aug * r + (1.0 - aug) * noise.to(r.device)
+            rows.append(r.to(device))
+        return torch.cat(rows, dim=0) if rows else None
+
+    def forward(self, x, timestep, context, transformer_options={}, minimax_payload=None, denoise_mask=None, audio_denoise_mask=None, **kwargs):
+        # the sampler carries the audio as (sigma_v / sigma_a) * x_audio; undo it outside
+        # the wrappers so they and the network see the stream's own latent and velocity
+        scale = float((minimax_payload or {}).get("audio_scale", 1.0))
+        audio_src = x[1]
+        if scale != 1.0:
+            shift_v = float(transformer_options.get("minimax_h3_sigma_shift_video", self.sigma_shift_video))
+            shift_a = float(transformer_options.get("minimax_h3_sigma_shift_audio", self.sigma_shift_audio))
+            sigma_v = (timestep.flatten()[0] / 1000.0).float().clamp(min=1e-6)
+            sigma_a = time_shift_sigma(sigma_v, shift_v, shift_a)
+            carry = (sigma_a / sigma_v).to(audio_src.dtype)
+            x = [x[0], audio_src * carry]
+
+        compile_allocations = comfy.model_prefetch.malloc_graph_enabled(x[0].device)
+        if compile_allocations:
+            out = [torch.empty_like(x[0]), torch.empty_like(x[1])]
+            comfy.model_prefetch.malloc_graph_begin(self, x[0].device)
+        graph_out = comfy.patcher_extension.WrapperExecutor.new_class_executor(
+            self._forward,
+            self,
+            comfy.patcher_extension.get_all_wrappers(comfy.patcher_extension.WrappersMP.DIFFUSION_MODEL, transformer_options)
+        ).execute(x, timestep, context, transformer_options, minimax_payload=minimax_payload,
+                  denoise_mask=denoise_mask, audio_denoise_mask=audio_denoise_mask, **kwargs)
+        if compile_allocations:
+            out[0].copy_(graph_out[0])
+            out[1].copy_(graph_out[1])
+            del graph_out
+            comfy.model_prefetch.malloc_graph_end()
+        else:
+            out = graph_out
+
+        if scale != 1.0:
+            # d/d(sigma_v) of the carried variable
+            out[1] = ((1.0 - scale) * (audio_src * carry)
+                      + (1.0 + (scale - 1.0) * sigma_a).to(out[1].dtype) * out[1])
+        return out
+
+    def _forward(self, x, timestep, context, transformer_options={}, minimax_payload=None, denoise_mask=None, audio_denoise_mask=None, **kwargs):
+        video_x, audio_x = x[0], x[1]
+        orig_t, orig_h, orig_w = video_x.shape[2], video_x.shape[3], video_x.shape[4]
+        video_x = comfy.ldm.common_dit.pad_to_patch_size(video_x, self.patch_size)
+        if video_x.shape[0] != 1:
+            raise ValueError("MiniMax H3 supports batch size 1")
+        payload = minimax_payload or {}
+        device = video_x.device
+        dtype = context.dtype  # compute dtype
+
+        latent_t, lat_h, lat_w = video_x.shape[2], video_x.shape[3], video_x.shape[4]
+        audio_t = audio_x.shape[-1]
+        text_len = context.shape[1]
+        # extra_conds prebuilds the layout once per sampling run
+        layout = payload.get("layout")
+        if layout is None or layout.signature != (text_len, latent_t, lat_h, lat_w, audio_t):
+            layout = PackedLayout(text_len, latent_t, lat_h, lat_w, audio_t,
+                                  keyframes=payload.get("keyframes"),
+                                  refs=payload.get("refs"))
+
+        transformer_options["minimax_h3_layout"] = layout   # segment spans for attention patches
+
+        # model_base passes model_sampling.timestep(sigma) = sigma * 1000
+        shift_v = float(transformer_options.get("minimax_h3_sigma_shift_video", self.sigma_shift_video))
+        shift_a = float(transformer_options.get("minimax_h3_sigma_shift_audio", self.sigma_shift_audio))
+        sigma_v = (timestep.flatten()[0] / 1000.0).float().clamp(min=1e-6)
+        t_v = float(1.0 - sigma_v)
+        t_a = float(1.0 - time_shift_sigma(sigma_v, shift_v, shift_a))
+
+        # distinct timesteps are known analytically: text/pad follow video, cond rows pin near 1
+        vis_aug = float(payload.get("visual_cond_noise_aug", VISUAL_COND_TIMESTEP))
+        aud_aug = float(payload.get("audio_cond_noise_aug", AUDIO_COND_TIMESTEP))
+        seg_t = {"text": t_v, "video": t_v, "audio": t_a,
+                 "cond": max(t_v, vis_aug), "ref_img": max(t_v, vis_aug),
+                 "cond_audio": max(t_a, aud_aug), "ref_audio": max(t_a, aud_aug)}
+
+        # masked rows run at their own strength: mask value m puts a row at sigma = m * sigma_stream,
+        # so its label is 1 - m * sigma, clamped at the cond timestep for fully preserved rows
+        t_pin_v = max(t_v, VISUAL_COND_TIMESTEP)
+        t_pin_a = max(t_a, AUDIO_COND_TIMESTEP)
+        video_rows_t = None
+        audio_rows_t = None
+        if denoise_mask is not None:
+            m = mask_row_values(denoise_mask[0, 0].to(torch.float32), latent_t, lat_h, lat_w)
+            if m is not None:
+                rows_t = (1.0 - m * sigma_v.to(m.device)).clamp(max=t_pin_v)
+                if rows_t.unique().numel() == 1:
+                    seg_t["video"] = float(rows_t[0])
+                else:
+                    video_rows_t = rows_t
+        if audio_denoise_mask is not None:
+            m = audio_denoise_mask[0, 0].to(torch.float32).reshape(-1)
+            if not bool((m >= 1.0 - 1e-3).all()):
+                sigma_a = 1.0 - t_a
+                rows_t = (1.0 - m * sigma_a).clamp(max=t_pin_a)
+                if rows_t.unique().numel() == 1:
+                    seg_t["audio"] = float(rows_t[0])
+                else:
+                    audio_rows_t = rows_t
+
+        unique_t = sorted({t_v, t_a} | {seg_t[k] for _, _, k in layout.segments}
+                          | (set(video_rows_t.unique().tolist()) if video_rows_t is not None else set())
+                          | (set(audio_rows_t.unique().tolist()) if audio_rows_t is not None else set()))
+        t_row = {t: i for i, t in enumerate(unique_t)}
+        seg_tag = {"text": 1, "video": 0, "audio": 2, "cond": 0, "ref_img": 0, "cond_audio": 2, "ref_audio": 2}
+
+        def rows_to_mod_index(rows_t, tag):
+            # per-row timestep values -> per-row mod-row indices into the t_emb table
+            levels = rows_t.unique()
+            base = torch.tensor([t_row[v] * 3 + tag for v in levels.tolist()],
+                                dtype=torch.long, device=rows_t.device)
+            return base[torch.searchsorted(levels, rows_t)]
+
+        text_tags = payload.get("text_token_tags")
+        mod_segments = []
+        for a, b, kind in layout.segments:
+            row_base = t_row[seg_t[kind]] * 3
+            if kind == "text" and text_tags is not None:
+                # the presentation text span mixes tags (vision pads carry the video modality) split into tag runs
+                tags = text_tags.view(-1).tolist()
+                run_start = 0
+                for i in range(1, b - a + 1):
+                    if i == b - a or tags[i] != tags[run_start]:
+                        mod_segments.append((a + run_start, a + i, row_base + int(tags[run_start])))
+                        run_start = i
+            elif kind == "video" and video_rows_t is not None:
+                mod_segments.append((a, b, rows_to_mod_index(video_rows_t, seg_tag[kind])))
+            elif kind == "audio" and audio_rows_t is not None:
+                mod_segments.append((a, b, rows_to_mod_index(audio_rows_t, seg_tag[kind])))
+            else:
+                mod_segments.append((a, b, row_base + seg_tag[kind]))
+
+        # embed
+        img_update = layout.img_update.to(device)
+        audio_update = layout.audio_update.to(device)
+        video_rows = patchify_video(video_x.to(torch.float32), self.patch_size)
+        audio_rows = pack_audio(audio_x.to(torch.float32))
+        cond_video_rows = self._cond_video_rows(payload, device)
+        cond_audio_rows = self._cond_audio_rows(payload, device)
+
+        all_video_rows = video_rows
+        if cond_video_rows is not None:
+            all_video_rows = torch.empty(img_update.shape[0], video_rows.shape[1], dtype=torch.float32, device=device)
+            all_video_rows[~img_update] = cond_video_rows
+            all_video_rows[img_update] = video_rows
+        all_audio_rows = audio_rows
+        if cond_audio_rows is not None:
+            all_audio_rows = torch.empty(audio_update.shape[0], audio_rows.shape[1], dtype=torch.float32, device=device)
+            all_audio_rows[~audio_update] = cond_audio_rows
+            all_audio_rows[audio_update] = audio_rows
+
+        video_embed = self.video_patch_proj(all_video_rows).to(dtype)
+        audio_embed = self.audio_patch_proj(all_audio_rows).to(dtype)
+        text_states = context[0]
+        if text_states.shape[-1] != self.hidden_size:
+            text_states = self.token_refiner(self.condition_proj(text_states),
+                                             transformer_options=transformer_options)
+
+        # segments are contiguous: assemble by slices, embed rows follow segment order
+        h = torch.empty(layout.seq_len, self.hidden_size, dtype=dtype, device=device)
+        voff = aoff = 0
+        for a, b, kind in layout.segments:
+            n = b - a
+            if kind == "text":
+                h[a:b] = text_states
+            elif kind in ("cond", "ref_img", "video"):
+                h[a:b] = video_embed[voff:voff + n]
+                voff += n
+            else:  # ref_audio / audio
+                h[a:b] = audio_embed[aoff:aoff + n]
+                aoff += n
+
+        t_vals = torch.tensor(unique_t, dtype=torch.float32, device=device)
+        if self.use_adaln_curves:
+            # adaln projections consume interpolated coordinates of the time-embedding curve
+            table = comfy.model_management.cast_to(self.adaln_t_table, device=device)
+            pos = t_vals.clamp(0.0, 1.0) * (table.shape[0] - 1)     # t in [0,1] -> fractional grid index, out-of-range t clamps to the curve ends
+            i0 = pos.floor().long().clamp(max=table.shape[0] - 2)   # lower grid row, max-clamp keeps t=1.0 on the last interval instead of reading past the table
+            t_emb = torch.lerp(table[i0], table[i0 + 1], (pos - i0).unsqueeze(1))  # blend the two rows by the fractional part
+        else:
+            t_emb = self.time_embedder(t_vals).to(dtype)
+
+        # rotation table computed once per forward, consumed by the kitchen split-half rope
+        rope_freqs = rope_rotation_table(self.rope_freqs(layout.position_ids, device), dtype)
+
+        # blocks
+        patches_replace = transformer_options.get("patches_replace", {})
+        blocks_replace = patches_replace.get("dit", {})
+        prefetch_queue = comfy.model_prefetch.make_prefetch_queue(list(self.blocks), device, transformer_options)
+        for i, block in enumerate(self.blocks):
+            comfy.model_prefetch.prefetch_queue_pop(prefetch_queue, device, block, malloc_scope="block")
+            transformer_options["block_index"] = i
+            if ("double_block", i) in blocks_replace:
+                def block_wrap(args):
+                    return {"img": block(args["img"], args["t_emb"], args["mod_segments"], args["rope_freqs"],
+                                         transformer_options=args["transformer_options"], attention=args.get("attention"))}
+                h = blocks_replace[("double_block", i)](
+                    {"img": h, "t_emb": t_emb, "mod_segments": mod_segments, "rope_freqs": rope_freqs,
+                     "layout": layout, "transformer_options": transformer_options},
+                    {"original_block": block_wrap})["img"]
+            else:
+                h = block(h, t_emb, mod_segments, rope_freqs, transformer_options=transformer_options)
+        comfy.model_prefetch.prefetch_queue_pop(prefetch_queue, device, None, malloc_scope="block")
+
+        # target streams are single contiguous segments (audio then video, last two)
+        va, vb, _ = next(s for s in layout.segments if s[2] == "video")
+        aa, ab, _ = next(s for s in layout.segments if s[2] == "audio")
+        if video_rows_t is not None:
+            video_seg = (va, vb, rows_to_mod_index(video_rows_t, 0) // 3)
+        else:
+            video_seg = (va, vb, t_row[seg_t["video"]])
+        if audio_rows_t is not None:
+            audio_seg = (aa, ab, rows_to_mod_index(audio_rows_t, 0) // 3)
+        else:
+            audio_seg = (aa, ab, t_row[seg_t["audio"]])
+        v, a = self.final_layer(h, t_emb, video_seg, audio_seg, sigma_v, transformer_options.get("sample_sigmas"), (shift_v, shift_a))
+
+        video_out = unpatchify_video(v, latent_t, lat_h // 2, lat_w // 2, self.latents_dim, self.patch_size)
+        video_out = video_out[:, :, :orig_t, :orig_h, :orig_w]
+        audio_out = unpack_audio(a)
+
+        return [-video_out.to(video_x.dtype), -audio_out.to(audio_x.dtype)]

--- a/tests/fixtures/model_v0345.py
+++ b/tests/fixtures/model_v0345.py
@@ -1,0 +1,732 @@
+"""MiniMax H3 audio-video DiT.
+
+Single-stream packed-token transformer denoising video (24ch, patch 1x2x2) and
+stereo audio (32ch, 40 Hz) latents jointly, conditioned on Qwen3-VL layer-50 hidden states.
+The packed sequence is:
+[text | cond rows | audio | video] for t2va/fl2va
+[text | reference blocks | audio | video] for ref2va
+
+Timestep domain: the model receives the *video* sigma from the sampler and
+derives per-token timesteps t = 1 - sigma internally; the audio stream runs on
+its own shifted schedule (sigma_shift video 12.0 / audio 3.0), mapped from the
+video sigma in closed form. The sampler carries the audio latent scaled onto the
+video schedule (ModelSamplingAV); forward() undoes that scale and converts the
+velocity back, so _forward only ever sees the stream's own latent.
+"""
+
+import math
+
+import torch
+import torch.nn as nn
+
+import comfy.ldm.common_dit
+import comfy.model_management
+import comfy.model_prefetch
+import comfy.ops
+import comfy.patcher_extension
+import comfy.quant_ops
+from comfy.ldm.modules.attention import AttentionTensorContainer, optimized_attention
+
+FRAME_PER_TOKEN = (1, 4, 4, 4, 4)
+FRAME_RESCALE = 5.0 / 3.0
+VISUAL_COND_TIMESTEP = 0.999
+AUDIO_COND_TIMESTEP = 1.0
+
+
+def time_shift_sigma(sigma, from_shift, to_shift):
+    # invert sigma = s*b/(1+(s-1)*b) to the base grid, re-apply the other shift
+    base = sigma / (from_shift + sigma * (1.0 - from_shift))
+    return to_shift * base / (1.0 + (to_shift - 1.0) * base)
+
+
+def patchify_video(latent, patch_size=(1, 2, 2)):
+    # [B, C, T, H, W] -> [B*t*h*w, C*pt*ph*pw]
+    b, c, t_full, h_full, w_full = latent.shape
+    pt, ph, pw = patch_size
+    t, h, w = t_full // pt, h_full // ph, w_full // pw
+    x = latent.reshape(b, c, t, pt, h, ph, w, pw)
+    x = torch.einsum("nctrhpwq->nthwcrpq", x)
+    return x.reshape(b * t * h * w, c * pt * ph * pw)
+
+
+def unpatchify_video(rows, t, h, w, c=24, patch_size=(1, 2, 2)):
+    pt, ph, pw = patch_size
+    x = rows.reshape(-1, t, h, w, c, pt, ph, pw)
+    x = torch.einsum("nthwcrpq->nctrhpwq", x)
+    return x.reshape(-1, c, t * pt, h * ph, w * pw)
+
+
+def pack_audio(latent):
+    # [B, C=32, ch=2, T] -> [ch*T, 32] channel-major (ch0 t0..T-1, ch1 t0..T-1)
+    b, c, ch, t = latent.shape
+    return latent[0].permute(1, 2, 0).reshape(ch * t, c)
+
+
+def unpack_audio(rows, ch=2):
+    t = rows.shape[0] // ch
+    return rows.reshape(ch, t, rows.shape[-1]).permute(2, 0, 1).unsqueeze(0)
+
+
+def _axis_from_sqrt_area(dim, patch, sqrt_area):
+    # linspace((1 - ratio) / 2, (1 + ratio) / 2, dim // patch, endpoint=False) * 32
+    ratio = dim / sqrt_area
+    n = dim // patch
+    return (torch.arange(n, dtype=torch.float64) * (ratio / n) + (1.0 - ratio) / 2.0) * 32.0
+
+
+def mask_row_values(mask, latent_t, lat_h, lat_w):
+    # [T, H, W] denoise mask (1 = generate) -> per-2x2-patch-row float in [0, 1],
+    # None when every row fully generates
+    m = torch.nn.functional.pad(mask, (0, lat_w - mask.shape[-1], 0, lat_h - mask.shape[-2]), mode="replicate")
+    m = m.reshape(latent_t, lat_h // 2, 2, lat_w // 2, 2).amax(dim=(2, 4))
+    values = m.reshape(-1)
+    if bool((values >= 1.0 - 1e-3).all()):
+        return None
+    return values
+
+
+def _frame_grid(h, w):
+    # area-normalized (h, w) coordinates of one latent frame's 2x2-patch rows
+    area = math.sqrt(h * w)
+    hh, ww = torch.meshgrid(_axis_from_sqrt_area(h, 2, area), _axis_from_sqrt_area(w, 2, area), indexing="ij")
+    return torch.stack([hh.reshape(-1), ww.reshape(-1)], dim=-1), _axis_from_sqrt_area(w, 2, area)
+
+
+def _video_t_spans(n):
+    return [FRAME_RESCALE * FRAME_PER_TOKEN[k % 5] for k in range(n)]
+
+
+def _video_t_grid(n, origin):
+    # origin + exclusive cumsum
+    spans = torch.tensor(_video_t_spans(n), dtype=torch.float64)
+    return float(origin) + torch.cat([torch.zeros(1, dtype=torch.float64), spans[:-1].cumsum(0)])
+
+
+def _ref_t_span(blk):
+    # time-axis span a reference block occupies ahead of the target streams
+    kind = blk["kind"]
+    if kind == "image":
+        return 1.0
+    if kind == "audio":
+        return float(blk["ref_audio_t"])
+    if kind in ("video", "video_audio"):
+        return max(float(blk["ref_audio_t"]), sum(_video_t_spans(blk["latent_t"])))
+    return 0.0
+
+
+def _audio_grid(cursor, t, w_low, w_high):
+    # channel-major stereo rows: t advances per latent frame, w pinned to the grid extremes per stereo channel, h stays 0
+    g = torch.zeros(t * 2, 3, dtype=torch.float64)
+    g[:, 0] = (cursor + torch.arange(t, dtype=torch.float64)).repeat(2)
+    g[:t, 2] = w_low
+    g[t:, 2] = w_high
+    return g
+
+
+def _video_grid(vt, frame, cursor):
+    g = torch.empty(vt, frame.shape[0], 3, dtype=torch.float64)
+    g[:, :, 0] = _video_t_grid(vt, cursor)[:, None]
+    g[:, :, 1:] = frame[None]
+    return g.reshape(-1, 3)
+
+
+class TimeEmbedder(nn.Module):
+    def __init__(self, freq_dim, hidden, out, dtype=None, device=None, operations=None):
+        super().__init__()
+        self.freq_dim = freq_dim
+        self.proj_in = operations.Linear(freq_dim, hidden, bias=True, dtype=dtype, device=device)
+        self.proj_out = operations.Linear(hidden, out, bias=True, dtype=dtype, device=device)
+
+    def forward(self, t):
+        # t: [M] in [0, 1]; fp32 throughout, cos before sin
+        half = self.freq_dim // 2
+        freqs = torch.exp(-math.log(10000.0) * torch.arange(half, dtype=torch.float32, device=t.device) / half)
+        args = t.to(torch.float32)[:, None] * freqs[None]
+        emb = torch.cat([torch.cos(args), torch.sin(args)], dim=-1)
+        return self.proj_out(nn.functional.silu(self.proj_in(emb)))
+
+
+def rope_rotation_table(angles, dtype):
+    """[S, rot_dim] pair angles -> [1, S, 1, rot_dim/2, 2, 2] rotation matrices."""
+    half = angles.shape[-1] // 2
+    ang = angles[:, :half]  # duplicated halves: [:, :half] == [:, half:]
+    c, s = torch.cos(ang), torch.sin(ang)
+    table = torch.stack([c, -s, s, c], dim=-1).reshape(1, angles.shape[0], 1, half, 2, 2)
+    return table.to(dtype)
+
+
+class Attention(nn.Module):
+    def __init__(self, hidden, heads, head_dim, eps, dtype=None, device=None, operations=None):
+        super().__init__()
+        self.heads = heads
+        self.head_dim = head_dim
+        inner = heads * head_dim
+        self.qkv_proj = operations.Linear(hidden, inner * 3, bias=False, dtype=dtype, device=device)
+        self.q_norm = operations.RMSNorm(head_dim, eps=eps, dtype=dtype, device=device)
+        self.k_norm = operations.RMSNorm(head_dim, eps=eps, dtype=dtype, device=device)
+        self.out_proj = operations.Linear(inner, hidden, bias=False, dtype=dtype, device=device)
+
+    def forward(self, x, rope_freqs=None, transformer_options={}):
+        s = x.shape[0]
+        q, k, v = self.qkv_proj(x).split(self.heads * self.head_dim, dim=-1)
+        v = v.view(s, self.heads, self.head_dim)
+        if rope_freqs is not None:
+            # fused per-head RMSNorm + partial split-half rope, in place on the qkv buffer
+            q = q.view(1, s, self.heads, self.head_dim)
+            k = k.view(1, s, self.heads, self.head_dim)
+            qw = comfy.model_management.cast_to(self.q_norm.weight, device=x.device)
+            kw = comfy.model_management.cast_to(self.k_norm.weight, device=x.device)
+            rot = rope_freqs.shape[-3] * 2
+            if comfy.model_management.in_training:
+                q, k = comfy.quant_ops.ck.rms_rope_split_half(
+                    q, k, rope_freqs, qw, kw, epsilon=self.q_norm.eps, rot_dim=rot)
+            else:
+                comfy.quant_ops.ck.rms_rope_split_half_(
+                    q, k, rope_freqs, qw, kw, epsilon=self.q_norm.eps, rot_dim=rot)
+            q = q[0]
+            k = k[0]
+        else:
+            q = self.q_norm(q.view(s, self.heads, self.head_dim))
+            k = self.k_norm(k.view(s, self.heads, self.head_dim))
+        v = v.clone()
+        q = AttentionTensorContainer(q.transpose(0, 1).unsqueeze(0))
+        k = AttentionTensorContainer(k.transpose(0, 1).unsqueeze(0))
+        v = AttentionTensorContainer(v.transpose(0, 1).unsqueeze(0))
+        out = optimized_attention(q, k, v, self.heads, mask=None, skip_reshape=True, transformer_options=transformer_options)
+        return self.out_proj(out.squeeze(0))
+
+
+class MLP(nn.Module):
+    def __init__(self, hidden, ffn, dtype=None, device=None, operations=None):
+        super().__init__()
+        self.fc1 = operations.Linear(hidden, ffn * 2, bias=False, dtype=dtype, device=device)
+        self.fc2 = operations.Linear(ffn, hidden, bias=False, dtype=dtype, device=device)
+
+    def forward(self, x):
+        return comfy.ops.linear_input_act(self.fc2, self.fc1(x), "swiglu")
+
+
+class AdalnProj(nn.Module):
+    def __init__(self, t_dim, hidden, expand, modalities, apply_silu=True,
+                 dtype=None, device=None, operations=None):
+        super().__init__()
+        self.expand = expand
+        self.modalities = modalities
+        self.hidden = hidden
+        self.apply_silu = apply_silu
+        self.linear = operations.Linear(t_dim, expand * hidden * modalities, bias=True, dtype=dtype, device=device)
+
+    def forward(self, t_emb):
+        # [M, t_dim] -> expand tensors of [M*modalities, hidden]
+        x = self.linear(nn.functional.silu(t_emb) if self.apply_silu else t_emb)
+        x = x.view(x.shape[0] * self.modalities, self.expand * self.hidden)
+        return x.chunk(self.expand, dim=-1)
+
+
+def _mod_row(vecs, row, dtype):
+    # row is a mod-row index, or a per-token LongTensor of mod-row indices
+    return vecs[row].to(dtype)
+
+
+def _mod_scale_shift(h, shift, scale, segments):
+    # segments: [(start, stop, mod_row)] covering h contiguously.
+    for a, b, row in segments:
+        h[a:b].mul_(1.0 + _mod_row(scale, row, h.dtype)).add_(_mod_row(shift, row, h.dtype))
+    return h
+
+
+def _mod_gate(x, gate, other, segments):
+    # other is the fresh attn/mlp output: accumulate the gated residual into the stream in place, one fused kernel per segment
+    for a, b, row in segments:
+        x[a:b].addcmul_(other[a:b], _mod_row(gate, row, x.dtype))
+    return x
+
+
+class RefinerBlock(nn.Module):
+    def __init__(self, hidden, heads, head_dim, ffn, eps, qk_eps, dtype=None, device=None, operations=None):
+        super().__init__()
+        self.norm1 = operations.RMSNorm(hidden, eps=eps, dtype=dtype, device=device)
+        self.norm2 = operations.RMSNorm(hidden, eps=eps, dtype=dtype, device=device)
+        self.attn = Attention(hidden, heads, head_dim, qk_eps, dtype=dtype, device=device, operations=operations)
+        self.mlp = MLP(hidden, ffn, dtype=dtype, device=device, operations=operations)
+
+    def forward(self, x, transformer_options={}):
+        # attn/mlp outputs are fresh: accumulate residuals in place
+        x = self.attn(self.norm1(x), transformer_options=transformer_options).add_(x)
+        return self.mlp(self.norm2(x)).add_(x)
+
+
+class TokenRefiner(nn.Module):
+    def __init__(self, num_layers, hidden, heads, head_dim, ffn, eps, qk_eps, final_eps,
+                 dtype=None, device=None, operations=None):
+        super().__init__()
+        self.blocks = nn.ModuleList([
+            RefinerBlock(hidden, heads, head_dim, ffn, eps, qk_eps, dtype=dtype, device=device, operations=operations)
+            for _ in range(num_layers)])
+        self.final_norm = operations.RMSNorm(hidden, eps=final_eps, dtype=dtype, device=device)
+
+    def forward(self, x, transformer_options={}):
+        for block in self.blocks:
+            x = block(x, transformer_options=transformer_options)
+        return self.final_norm(x)
+
+
+class DiTBlock(nn.Module):
+    def __init__(self, hidden, heads, head_dim, ffn, t_dim, eps, qk_eps,
+                 apply_silu=True, adaln_dtype=None, dtype=None, device=None, operations=None):
+        super().__init__()
+        self.norm1 = operations.RMSNorm(hidden, eps=eps, dtype=dtype, device=device)
+        self.norm2 = operations.RMSNorm(hidden, eps=eps, dtype=dtype, device=device)
+        self.attn = Attention(hidden, heads, head_dim, qk_eps, dtype=dtype, device=device, operations=operations)
+        self.mlp = MLP(hidden, ffn, dtype=dtype, device=device, operations=operations)
+        self.adaln_proj = AdalnProj(t_dim, hidden, 6, 3, apply_silu=apply_silu,
+                                    dtype=adaln_dtype if adaln_dtype is not None else dtype,
+                                    device=device, operations=operations)
+
+    def forward(self, x, t_emb, mod_segments, rope_freqs, transformer_options={}):
+        shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = self.adaln_proj(t_emb)
+        h = _mod_scale_shift(self.norm1(x), shift_msa, scale_msa, mod_segments)
+        x = _mod_gate(x, gate_msa, self.attn(h, rope_freqs=rope_freqs, transformer_options=transformer_options), mod_segments)
+        h = _mod_scale_shift(self.norm2(x), shift_mlp, scale_mlp, mod_segments)
+        return _mod_gate(x, gate_mlp, self.mlp(h), mod_segments)
+
+
+class FinalLayer(nn.Module):
+    def __init__(self, hidden, t_dim, video_dim, audio_dim, eps, apply_silu=True, adaln_dtype=None,
+                 dtype=None, device=None, operations=None):
+        super().__init__()
+        self.norm = operations.RMSNorm(hidden, eps=eps, dtype=dtype, device=device)
+        self.adaln_proj = AdalnProj(t_dim, hidden, 2, 1, apply_silu=apply_silu,
+                                    dtype=adaln_dtype if adaln_dtype is not None else dtype,
+                                    device=device, operations=operations)
+        # output heads are the checkpoint's fp32 island; norm/adaln are stored at model dtype
+        self.video_out = operations.Linear(hidden, video_dim, bias=True, dtype=torch.float32, device=device)
+        self.audio_out = operations.Linear(hidden, audio_dim, bias=True, dtype=torch.float32, device=device)
+
+    def forward(self, x, t_emb, video_seg, audio_seg):
+        # video_seg / audio_seg: (start, stop, row) of the target streams, where row
+        # is a mod-row index or a per-token blend (see _mod_row)
+        shift, scale = self.adaln_proj(t_emb)
+
+        def mod(seg):
+            a, b, row = seg
+            return (self.norm(x[a:b]) * (1.0 + _mod_row(scale, row, scale.dtype)) + _mod_row(shift, row, shift.dtype)).to(torch.float32)
+
+        return self.video_out(mod(video_seg)), self.audio_out(mod(audio_seg))
+
+
+class PackedLayout:
+    """Static packed-sequence structure for one shape/conditioning signature."""
+
+    def __init__(self, text_len, latent_t, latent_h, latent_w, audio_t, keyframes=None, refs=None):
+        frame, w_grid = _frame_grid(latent_h, latent_w)
+        frame_rows = frame.shape[0]
+
+        segments = [("text", text_len)]  # (kind, n_rows)
+        g = torch.zeros(text_len, 3, dtype=torch.float64)
+        g[:, 0] = torch.arange(text_len, dtype=torch.float64)
+        pos = [g]  # per segment: [n, 3] float64 (t, h, w)
+
+        img_pos, img_update = [], []
+        audio_pos, audio_update = [], []
+        row = text_len
+
+        target_audio_w = (float(w_grid[0]), float(w_grid[-1]))
+        # refs pack between text and the targets, so the target timeline starts after their spans
+        cursor = float(text_len)
+        for blk in refs or ():
+            cursor += _ref_t_span(blk)
+
+        if keyframes:
+            # fl2va: keyframe cond rows right after text, sharing the target spatial grid;
+            # anchors count from the target timeline origin, FRAME_RESCALE per pixel frame, 1.0 per audio latent frame
+            for kf in keyframes:
+                cond_t = cursor + FRAME_RESCALE * kf["resolved_frame_index"]
+                video_latent = kf.get("latent")
+                if video_latent is not None:
+                    vt = video_latent.shape[2]
+                    n = vt * frame_rows
+                    segments.append(("cond", n))
+                    pos.append(_video_grid(vt, frame, cond_t))
+                    img_pos.append(torch.arange(row, row + n))
+                    img_update.append(torch.zeros(n, dtype=torch.bool))
+                    row += n
+                audio_latent = kf.get("audio_latent")
+                if audio_latent is not None:
+                    rt = audio_latent.shape[-1]
+                    segments.append(("cond_audio", rt * 2))
+                    pos.append(_audio_grid(cond_t, rt, *target_audio_w))
+                    audio_pos.append(torch.arange(row, row + rt * 2))
+                    audio_update.append(torch.zeros(rt * 2, dtype=torch.bool))
+                    row += rt * 2
+
+        if refs:
+            cursor = float(text_len)
+            for blk in refs:
+                kind = blk["kind"]
+                if kind == "image":
+                    r_frame, _ = _frame_grid(blk["latent_h"], blk["latent_w"])
+                    n = r_frame.shape[0]
+                    g = torch.empty(n, 3, dtype=torch.float64)
+                    g[:, 0] = cursor
+                    g[:, 1:] = r_frame
+                    segments.append(("ref_img", n))
+                    pos.append(g)
+                    img_pos.append(torch.arange(row, row + n))
+                    img_update.append(torch.zeros(n, dtype=torch.bool))
+                    row += n
+                    cursor += 1.0
+                elif kind == "audio":
+                    rt = blk["ref_audio_t"]
+                    if rt > 0:
+                        segments.append(("ref_audio", rt * 2))
+                        pos.append(_audio_grid(cursor, rt, *target_audio_w))
+                        audio_pos.append(torch.arange(row, row + rt * 2))
+                        audio_update.append(torch.zeros(rt * 2, dtype=torch.bool))
+                        row += rt * 2
+                    cursor += float(rt)
+                elif kind in ("video", "video_audio"):
+                    # the block's audio rows pack immediately before its video
+                    # rows, both sharing the cursor origin
+                    rt = blk["ref_audio_t"]
+                    vt = blk["latent_t"]
+                    r_frame, r_w_grid = _frame_grid(blk["latent_h"], blk["latent_w"])
+                    if rt > 0:
+                        segments.append(("ref_audio", rt * 2))
+                        pos.append(_audio_grid(cursor, rt, float(r_w_grid[0]), float(r_w_grid[-1])))
+                        audio_pos.append(torch.arange(row, row + rt * 2))
+                        audio_update.append(torch.zeros(rt * 2, dtype=torch.bool))
+                        row += rt * 2
+                    n = vt * r_frame.shape[0]
+                    segments.append(("ref_img", n))
+                    pos.append(_video_grid(vt, r_frame, cursor))
+                    img_pos.append(torch.arange(row, row + n))
+                    img_update.append(torch.zeros(n, dtype=torch.bool))
+                    row += n
+                    cursor += max(float(rt), sum(_video_t_spans(vt)))
+
+        # target audio then target video, always the last two segments
+        segments.append(("audio", audio_t * 2))
+        pos.append(_audio_grid(cursor, audio_t, *target_audio_w))
+        audio_pos.append(torch.arange(row, row + audio_t * 2))
+        audio_update.append(torch.ones(audio_t * 2, dtype=torch.bool))
+        row += audio_t * 2
+
+        n_video = latent_t * frame_rows
+        segments.append(("video", n_video))
+        pos.append(_video_grid(latent_t, frame, cursor))
+        img_pos.append(torch.arange(row, row + n_video))
+        img_update.append(torch.ones(n_video, dtype=torch.bool))
+        row += n_video
+
+        self.seq_len = row
+        self.position_ids = torch.cat(pos)  # [S, 3] float64
+        self.img_pos = torch.cat(img_pos)
+        self.img_update = torch.cat(img_update)
+        self.audio_pos = torch.cat(audio_pos)
+        self.audio_update = torch.cat(audio_update)
+        self.signature = (text_len, latent_t, latent_h, latent_w, audio_t)
+        # contiguous segment table (start, stop, kind)
+        # kinds: text / cond / cond_audio / ref_img / ref_audio / audio / video
+        # the packed sequence is uniform per segment in (modality tag, timestep class),
+        # except the text span (tag runs resolved at forward time from the presentation tags)
+        seg_abs = []
+        off = 0
+        for kind, n in segments:
+            seg_abs.append((off, off + n, kind))
+            off += n
+        self.segments = seg_abs
+
+
+class MiniMaxH3Model(nn.Module):
+    def __init__(self, hidden_size=5376, num_layers=50, token_refiner_num_layers=2,
+                 num_attention_heads=56, attention_head_dim=128, ffn_hidden_size=14336,
+                 latents_dim=24, audio_latents_dim=32, patch_size=(1, 2, 2), text_dim=5120,
+                 timestep_input_dim=256, time_embed_hidden_size=5376, time_embed_dim=2688,
+                 rope_inv_freq_len=16, norm_eps=1e-5, qk_norm_eps=1e-5, final_norm_eps=1e-5,
+                 sigma_shift_video=12.0, sigma_shift_audio=3.0,
+                 adaln_curve_grid=None,
+                 image_model=None, dtype=None, device=None, operations=None, **kwargs):
+        super().__init__()
+        self.dtype = dtype
+        self.hidden_size = hidden_size
+        self.patch_size = tuple(patch_size)
+        self.latents_dim = latents_dim
+        self.audio_latents_dim = audio_latents_dim
+        self.sigma_shift_video = sigma_shift_video
+        self.sigma_shift_audio = sigma_shift_audio
+        self.use_adaln_curves = adaln_curve_grid is not None
+        # curve-form checkpoints replace the time embedder and full-width adaln weights with a small shared basis of the time-embedding curve
+        curve = {"apply_silu": not self.use_adaln_curves,
+                 "adaln_dtype": torch.float32 if self.use_adaln_curves else dtype}
+        video_patch_dim = latents_dim * self.patch_size[0] * self.patch_size[1] * self.patch_size[2]
+
+        self.video_patch_proj = operations.Linear(video_patch_dim, hidden_size, bias=True, dtype=torch.float32, device=device)
+        self.audio_patch_proj = operations.Linear(audio_latents_dim, hidden_size, bias=True, dtype=torch.float32, device=device)
+        self.condition_proj = operations.Linear(text_dim, hidden_size, bias=True, dtype=dtype, device=device)
+        if self.use_adaln_curves:
+            self.register_buffer("adaln_t_table", torch.empty(adaln_curve_grid, time_embed_dim, dtype=torch.float32))
+        else:
+            self.time_embedder = TimeEmbedder(timestep_input_dim, time_embed_hidden_size, time_embed_dim,
+                                              dtype=torch.float32, device=device, operations=operations)
+        self.rope = nn.Module()
+        self.rope.register_buffer("inv_freq", torch.empty(rope_inv_freq_len, dtype=torch.float32))
+        self.token_refiner = TokenRefiner(token_refiner_num_layers, hidden_size, num_attention_heads,
+                                          attention_head_dim, ffn_hidden_size, norm_eps, qk_norm_eps,
+                                          final_norm_eps, dtype=dtype, device=device, operations=operations)
+        self.blocks = nn.ModuleList([
+            DiTBlock(hidden_size, num_attention_heads, attention_head_dim, ffn_hidden_size,
+                     time_embed_dim, norm_eps, qk_norm_eps, **curve, dtype=dtype, device=device, operations=operations)
+            for _ in range(num_layers)])
+        self.final_layer = FinalLayer(hidden_size, time_embed_dim, video_patch_dim, audio_latents_dim,
+                                      final_norm_eps, **curve, dtype=dtype, device=device, operations=operations)
+
+    def preprocess_text_embeds(self, text_states):
+        """[B, L, text_dim] Qwen states -> [B, L, hidden] refined text embeds."""
+        if text_states.shape[-1] == self.hidden_size:
+            return text_states
+        return self.token_refiner(self.condition_proj(text_states[0])).unsqueeze(0)
+
+    def rope_freqs(self, position_ids, device):
+        # [S, 3] float64 -> [S, 96] fp32
+        pos = position_ids.to(torch.float32).to(device)
+        inv = comfy.model_management.cast_to(self.rope.inv_freq, device=device)
+        per_axis = pos.unsqueeze(-1) * inv.view(1, 1, -1)      # [S, 3, 16]
+        t_f, h_f, w_f = per_axis.unbind(dim=1)
+        half = torch.cat((t_f, h_f, w_f), dim=-1)              # [S, 48]
+        return torch.cat((half, half), dim=-1)                 # [S, 96]
+
+    def _cond_video_rows(self, payload, device):
+        """Concatenated visual condition rows (normalized latents -> patchified), with condition noise augmentation."""
+        rows = []
+        aug = payload.get("visual_cond_noise_aug", VISUAL_COND_TIMESTEP)
+        seed = int(payload.get("seed", 0))
+        # every condition intentionally restarts the same RNG stream
+        for z in payload.get("cond_video_latents", []):
+            r = patchify_video(z.to(torch.float32), self.patch_size)
+            if aug < 1.0:
+                gen = torch.Generator("cpu").manual_seed(seed)
+                noise = torch.randn(r.shape, generator=gen, dtype=torch.float32)
+                r = aug * r + (1.0 - aug) * noise.to(r.device)
+            rows.append(r.to(device))
+        return torch.cat(rows, dim=0) if rows else None
+
+    def _cond_audio_rows(self, payload, device):
+        rows = []
+        aug = payload.get("audio_cond_noise_aug", AUDIO_COND_TIMESTEP)
+        seed = int(payload.get("seed", 0)) + 1
+        for z in payload.get("cond_audio_latents", []):
+            r = pack_audio(z.to(torch.float32))
+            if aug < 1.0:
+                gen = torch.Generator("cpu").manual_seed(seed)
+                noise = torch.randn(r.shape, generator=gen, dtype=torch.float32)
+                r = aug * r + (1.0 - aug) * noise.to(r.device)
+            rows.append(r.to(device))
+        return torch.cat(rows, dim=0) if rows else None
+
+    def forward(self, x, timestep, context, transformer_options={}, minimax_payload=None, denoise_mask=None, audio_denoise_mask=None, **kwargs):
+        # the sampler carries the audio as (sigma_v / sigma_a) * x_audio; undo it outside
+        # the wrappers so they and the network see the stream's own latent and velocity
+        scale = float((minimax_payload or {}).get("audio_scale", 1.0))
+        audio_src = x[1]
+        if scale != 1.0:
+            shift_v = float(transformer_options.get("minimax_h3_sigma_shift_video", self.sigma_shift_video))
+            shift_a = float(transformer_options.get("minimax_h3_sigma_shift_audio", self.sigma_shift_audio))
+            sigma_v = (timestep.flatten()[0] / 1000.0).float().clamp(min=1e-6)
+            sigma_a = time_shift_sigma(sigma_v, shift_v, shift_a)
+            carry = (sigma_a / sigma_v).to(audio_src.dtype)
+            x = [x[0], audio_src * carry]
+
+        out = comfy.patcher_extension.WrapperExecutor.new_class_executor(
+            self._forward,
+            self,
+            comfy.patcher_extension.get_all_wrappers(comfy.patcher_extension.WrappersMP.DIFFUSION_MODEL, transformer_options)
+        ).execute(x, timestep, context, transformer_options, minimax_payload=minimax_payload,
+                  denoise_mask=denoise_mask, audio_denoise_mask=audio_denoise_mask, **kwargs)
+
+        if scale != 1.0:
+            # d/d(sigma_v) of the carried variable
+            out[1] = ((1.0 - scale) * (audio_src * carry)
+                      + (1.0 + (scale - 1.0) * sigma_a).to(out[1].dtype) * out[1])
+        return out
+
+    def _forward(self, x, timestep, context, transformer_options={}, minimax_payload=None, denoise_mask=None, audio_denoise_mask=None, **kwargs):
+        video_x, audio_x = x[0], x[1]
+        orig_t, orig_h, orig_w = video_x.shape[2], video_x.shape[3], video_x.shape[4]
+        video_x = comfy.ldm.common_dit.pad_to_patch_size(video_x, self.patch_size)
+        if video_x.shape[0] != 1:
+            raise ValueError("MiniMax H3 supports batch size 1")
+        payload = minimax_payload or {}
+        device = video_x.device
+        dtype = context.dtype  # compute dtype
+
+        latent_t, lat_h, lat_w = video_x.shape[2], video_x.shape[3], video_x.shape[4]
+        audio_t = audio_x.shape[-1]
+        text_len = context.shape[1]
+        # extra_conds prebuilds the layout once per sampling run
+        layout = payload.get("layout")
+        if layout is None or layout.signature != (text_len, latent_t, lat_h, lat_w, audio_t):
+            layout = PackedLayout(text_len, latent_t, lat_h, lat_w, audio_t,
+                                  keyframes=payload.get("keyframes"),
+                                  refs=payload.get("refs"))
+
+        # model_base passes model_sampling.timestep(sigma) = sigma * 1000
+        shift_v = float(transformer_options.get("minimax_h3_sigma_shift_video", self.sigma_shift_video))
+        shift_a = float(transformer_options.get("minimax_h3_sigma_shift_audio", self.sigma_shift_audio))
+        sigma_v = (timestep.flatten()[0] / 1000.0).float().clamp(min=1e-6)
+        t_v = float(1.0 - sigma_v)
+        t_a = float(1.0 - time_shift_sigma(sigma_v, shift_v, shift_a))
+
+        # distinct timesteps are known analytically: text/pad follow video, cond rows pin near 1
+        vis_aug = float(payload.get("visual_cond_noise_aug", VISUAL_COND_TIMESTEP))
+        aud_aug = float(payload.get("audio_cond_noise_aug", AUDIO_COND_TIMESTEP))
+        seg_t = {"text": t_v, "video": t_v, "audio": t_a,
+                 "cond": max(t_v, vis_aug), "ref_img": max(t_v, vis_aug),
+                 "cond_audio": max(t_a, aud_aug), "ref_audio": max(t_a, aud_aug)}
+
+        # masked rows run at their own strength: mask value m puts a row at sigma = m * sigma_stream,
+        # so its label is 1 - m * sigma, clamped at the cond timestep for fully preserved rows
+        t_pin_v = max(t_v, VISUAL_COND_TIMESTEP)
+        t_pin_a = max(t_a, AUDIO_COND_TIMESTEP)
+        video_rows_t = None
+        audio_rows_t = None
+        if denoise_mask is not None:
+            m = mask_row_values(denoise_mask[0, 0].to(torch.float32), latent_t, lat_h, lat_w)
+            if m is not None:
+                rows_t = (1.0 - m * sigma_v.to(m.device)).clamp(max=t_pin_v)
+                if rows_t.unique().numel() == 1:
+                    seg_t["video"] = float(rows_t[0])
+                else:
+                    video_rows_t = rows_t
+        if audio_denoise_mask is not None:
+            m = audio_denoise_mask[0, 0].to(torch.float32).reshape(-1)
+            if not bool((m >= 1.0 - 1e-3).all()):
+                sigma_a = 1.0 - t_a
+                rows_t = (1.0 - m * sigma_a).clamp(max=t_pin_a)
+                if rows_t.unique().numel() == 1:
+                    seg_t["audio"] = float(rows_t[0])
+                else:
+                    audio_rows_t = rows_t
+
+        unique_t = sorted({t_v, t_a} | {seg_t[k] for _, _, k in layout.segments}
+                          | (set(video_rows_t.unique().tolist()) if video_rows_t is not None else set())
+                          | (set(audio_rows_t.unique().tolist()) if audio_rows_t is not None else set()))
+        t_row = {t: i for i, t in enumerate(unique_t)}
+        seg_tag = {"text": 1, "video": 0, "audio": 2, "cond": 0, "ref_img": 0, "cond_audio": 2, "ref_audio": 2}
+
+        def rows_to_mod_index(rows_t, tag):
+            # per-row timestep values -> per-row mod-row indices into the t_emb table
+            levels = rows_t.unique()
+            base = torch.tensor([t_row[v] * 3 + tag for v in levels.tolist()],
+                                dtype=torch.long, device=rows_t.device)
+            return base[torch.searchsorted(levels, rows_t)]
+
+        text_tags = payload.get("text_token_tags")
+        mod_segments = []
+        for a, b, kind in layout.segments:
+            row_base = t_row[seg_t[kind]] * 3
+            if kind == "text" and text_tags is not None:
+                # the presentation text span mixes tags (vision pads carry the video modality) split into tag runs
+                tags = text_tags.view(-1).tolist()
+                run_start = 0
+                for i in range(1, b - a + 1):
+                    if i == b - a or tags[i] != tags[run_start]:
+                        mod_segments.append((a + run_start, a + i, row_base + int(tags[run_start])))
+                        run_start = i
+            elif kind == "video" and video_rows_t is not None:
+                mod_segments.append((a, b, rows_to_mod_index(video_rows_t, seg_tag[kind])))
+            elif kind == "audio" and audio_rows_t is not None:
+                mod_segments.append((a, b, rows_to_mod_index(audio_rows_t, seg_tag[kind])))
+            else:
+                mod_segments.append((a, b, row_base + seg_tag[kind]))
+
+        # embed
+        img_update = layout.img_update.to(device)
+        audio_update = layout.audio_update.to(device)
+        video_rows = patchify_video(video_x.to(torch.float32), self.patch_size)
+        audio_rows = pack_audio(audio_x.to(torch.float32))
+        cond_video_rows = self._cond_video_rows(payload, device)
+        cond_audio_rows = self._cond_audio_rows(payload, device)
+
+        all_video_rows = video_rows
+        if cond_video_rows is not None:
+            all_video_rows = torch.empty(img_update.shape[0], video_rows.shape[1], dtype=torch.float32, device=device)
+            all_video_rows[~img_update] = cond_video_rows
+            all_video_rows[img_update] = video_rows
+        all_audio_rows = audio_rows
+        if cond_audio_rows is not None:
+            all_audio_rows = torch.empty(audio_update.shape[0], audio_rows.shape[1], dtype=torch.float32, device=device)
+            all_audio_rows[~audio_update] = cond_audio_rows
+            all_audio_rows[audio_update] = audio_rows
+
+        video_embed = self.video_patch_proj(all_video_rows).to(dtype)
+        audio_embed = self.audio_patch_proj(all_audio_rows).to(dtype)
+        text_states = context[0]
+        if text_states.shape[-1] != self.hidden_size:
+            text_states = self.token_refiner(self.condition_proj(text_states),
+                                             transformer_options=transformer_options)
+
+        # segments are contiguous: assemble by slices, embed rows follow segment order
+        h = torch.empty(layout.seq_len, self.hidden_size, dtype=dtype, device=device)
+        voff = aoff = 0
+        for a, b, kind in layout.segments:
+            n = b - a
+            if kind == "text":
+                h[a:b] = text_states
+            elif kind in ("cond", "ref_img", "video"):
+                h[a:b] = video_embed[voff:voff + n]
+                voff += n
+            else:  # ref_audio / audio
+                h[a:b] = audio_embed[aoff:aoff + n]
+                aoff += n
+
+        t_vals = torch.tensor(unique_t, dtype=torch.float32, device=device)
+        if self.use_adaln_curves:
+            # adaln projections consume interpolated coordinates of the time-embedding curve
+            table = comfy.model_management.cast_to(self.adaln_t_table, device=device)
+            pos = t_vals.clamp(0.0, 1.0) * (table.shape[0] - 1)     # t in [0,1] -> fractional grid index, out-of-range t clamps to the curve ends
+            i0 = pos.floor().long().clamp(max=table.shape[0] - 2)   # lower grid row, max-clamp keeps t=1.0 on the last interval instead of reading past the table
+            t_emb = torch.lerp(table[i0], table[i0 + 1], (pos - i0).unsqueeze(1))  # blend the two rows by the fractional part
+        else:
+            t_emb = self.time_embedder(t_vals).to(dtype)
+
+        # rotation table computed once per forward, consumed by the kitchen split-half rope
+        rope_freqs = rope_rotation_table(self.rope_freqs(layout.position_ids, device), dtype)
+
+        # blocks
+        patches_replace = transformer_options.get("patches_replace", {})
+        blocks_replace = patches_replace.get("dit", {})
+        prefetch_queue = comfy.model_prefetch.make_prefetch_queue(list(self.blocks), device, transformer_options)
+        for i, block in enumerate(self.blocks):
+            comfy.model_prefetch.prefetch_queue_pop(prefetch_queue, device, block)
+            if ("double_block", i) in blocks_replace:
+                def block_wrap(args):
+                    return {"img": block(args["img"], args["t_emb"], args["mod_segments"], args["rope_freqs"],
+                                         transformer_options=args["transformer_options"])}
+                h = blocks_replace[("double_block", i)](
+                    {"img": h, "t_emb": t_emb, "mod_segments": mod_segments, "rope_freqs": rope_freqs,
+                     "transformer_options": transformer_options},
+                    {"original_block": block_wrap})["img"]
+            else:
+                h = block(h, t_emb, mod_segments, rope_freqs, transformer_options=transformer_options)
+        if prefetch_queue is not None:
+            comfy.model_prefetch.prefetch_queue_pop(prefetch_queue, device, None)
+
+        # target streams are single contiguous segments (audio then video, last two)
+        va, vb, _ = next(s for s in layout.segments if s[2] == "video")
+        aa, ab, _ = next(s for s in layout.segments if s[2] == "audio")
+        if video_rows_t is not None:
+            video_seg = (va, vb, rows_to_mod_index(video_rows_t, 0) // 3)
+        else:
+            video_seg = (va, vb, t_row[seg_t["video"]])
+        if audio_rows_t is not None:
+            audio_seg = (aa, ab, rows_to_mod_index(audio_rows_t, 0) // 3)
+        else:
+            audio_seg = (aa, ab, t_row[seg_t["audio"]])
+        v, a = self.final_layer(h, t_emb, video_seg, audio_seg)
+
+        video_out = unpatchify_video(v, latent_t, lat_h // 2, lat_w // 2, self.latents_dim, self.patch_size)
+        video_out = video_out[:, :, :orig_t, :orig_h, :orig_w]
+        audio_out = unpack_audio(a)
+
+        return [-video_out.to(video_x.dtype), -audio_out.to(audio_x.dtype)]

--- a/tests/test_runtime_patch.py
+++ b/tests/test_runtime_patch.py
@@ -1,4 +1,4 @@
-"""Dependency-free structural and dtype-flow tests for v0.1.3."""
+"""Dependency-free structural and dtype-flow tests for v0.1.4."""
 
 from __future__ import annotations
 
@@ -154,10 +154,12 @@ class _FakeFinalLayer:
         self.audio_out = _FakeLinear("audio_out")
 
     def forward(self, x, t_emb, video_seg, audio_seg):
-        adaln_proj = self.adaln_proj
-        video_out = self.video_out
-        audio_out = self.audio_out
-        return x, t_emb, video_seg, audio_seg, adaln_proj, video_out, audio_out
+        shift, scale = self.adaln_proj(t_emb)
+        va, vb, vrow = video_seg
+        aa, ab, arow = audio_seg
+        hv = self.norm(x[va:vb]) * (1.0 + scale[vrow]) + shift[vrow]
+        ha = self.norm(x[aa:ab]) * (1.0 + scale[arow]) + shift[arow]
+        return self.video_out(hv.to(dtype="float32")), self.audio_out(ha.to(dtype="float32"))
 
 
 class _FakeBlock:
@@ -359,7 +361,7 @@ class RuntimePatchTests(unittest.TestCase):
         return model, supported
 
     def _load_runtime(self):
-        spec = importlib.util.spec_from_file_location("test_minimax_h3_v013_runtime", self.runtime_path)
+        spec = importlib.util.spec_from_file_location("test_minimax_h3_v014_runtime", self.runtime_path)
         module = importlib.util.module_from_spec(spec)
         sys.modules[spec.name] = module
         spec.loader.exec_module(module)
@@ -369,7 +371,7 @@ class RuntimePatchTests(unittest.TestCase):
         model_module, supported = self._install_fake_modules()
         runtime = self._load_runtime()
         self.assertTrue(runtime.PATCH_STATUS["installed"])
-        self.assertEqual(runtime.PACKAGE_VERSION, "0.1.3")
+        self.assertEqual(runtime.PACKAGE_VERSION, "0.1.4")
         self.assertEqual(
             supported.MiniMaxH3.supported_inference_dtypes,
             ["float16", "bfloat16", "float32"],
@@ -523,7 +525,7 @@ class RuntimePatchTests(unittest.TestCase):
         runtime = self._load_runtime()
         second = runtime.install_patch()
         self.assertTrue(second["installed"])
-        self.assertEqual(second["version"], "0.1.3")
+        self.assertEqual(second["version"], "0.1.4")
         self.assertEqual(second["reason"], "already installed")
 
     def test_late_conflict_keeps_new_instances_unmodified(self):
@@ -552,8 +554,7 @@ class RuntimePatchTests(unittest.TestCase):
         self.assertIn("out.squeeze(0) / OUT_PROJ_SCALE", source)
         self.assertIn("hidden / MLP_FC2_SCALE", source)
         self.assertIn("t_emb = t_emb.to(dtype=torch.float32)", source)
-        self.assertIn("self.video_out(hv.to(dtype=torch.float32))", source)
-        self.assertIn("self.audio_out(ha.to(dtype=torch.float32))", source)
+        self.assertIn("_ORIGINAL_FINAL_FORWARD(self, x, t_emb, video_seg, audio_seg, *args, **kwargs)", source)
 
     def test_runtime_code_has_no_source_file_write_api(self):
         source = self.runtime_path.read_text(encoding="utf-8")
@@ -576,8 +577,6 @@ class RuntimePatchTests(unittest.TestCase):
         expected = {
             "_patched_attention_forward": "d423ee3d5e20c19d4219c133a7c32459ef37a3d3135df6436ba47a4d90d4adb3",
             "_patched_mlp_forward": "aa8b8c08b1d41d7dd0a0ef3bfd124f72293130697865014443016ad8b336f9ef",
-            "_patched_final_forward": "96582fee3f8b3c661aabbaeb484f2e8e4efc2dfd589801e3648e413cd590d394",
-            "_patched_block_forward": "866c73f012a7f6c62e1c84a207832c184ff1d335f499d72da3200845b79496ee",
         }
 
         for name, expected_hash in expected.items():

--- a/tests/test_upstream_compat.py
+++ b/tests/test_upstream_compat.py
@@ -1,0 +1,182 @@
+"""Run real upstream method bodies with trace tensors; no CUDA claim is made."""
+
+import ast
+from pathlib import Path
+import sys
+import types
+import unittest
+
+import test_runtime_patch as helpers
+
+
+class _Schedule:
+    def __init__(self, values):
+        self.values = values
+        self.shape = (len(values),)
+
+    def __sub__(self, value):
+        return _Schedule([x - value for x in self.values])
+
+    def abs(self):
+        return _Schedule([abs(x) for x in self.values])
+
+    def argmin(self):
+        return min(range(len(self.values)), key=self.values.__getitem__)
+
+    def __getitem__(self, index):
+        return self.values[index]
+
+
+class UpstreamCompatibilityTests(unittest.TestCase):
+    setUp = helpers.RuntimePatchTests.setUp
+    tearDown = helpers.RuntimePatchTests.tearDown
+    _install_fake_modules = helpers.RuntimePatchTests._install_fake_modules
+    _load_runtime = helpers.RuntimePatchTests._load_runtime
+
+    def load_upstream(self, filename):
+        model, supported = self._install_fake_modules()
+        path = Path(__file__).parent / "fixtures" / filename
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        namespace = dict(vars(model), torch=sys.modules["torch"])
+        for name in ("_mod_row", "time_shift_sigma"):
+            function = next(n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name == name)
+            exec(compile(ast.Module(body=[function], type_ignores=[]), str(path), "exec"), namespace)
+        self.pdd_calls = []
+
+        def pdd_head(head, h, n, start, stop, flow_shift):
+            self.pdd_calls.append((head.name, h.dtype, n, start, stop, flow_shift))
+            return head(h)
+
+        namespace["_pdd_head"] = pdd_head
+        for class_name, methods in {
+            "Attention": ("forward",), "MLP": ("forward",),
+            "DiTBlock": ("forward",), "FinalLayer": ("forward",),
+            "MiniMaxH3Model": ("__init__", "_forward"),
+            "PackedLayout": ("__init__",),
+        }.items():
+            source_class = next(n for n in tree.body if isinstance(n, ast.ClassDef) and n.name == class_name)
+            cls = type(class_name, (), {"__module__": model.__name__})
+            for method in methods:
+                function = next(n for n in source_class.body if isinstance(n, ast.FunctionDef) and n.name == method)
+                exec(compile(ast.Module(body=[function], type_ignores=[]), str(path), "exec"), namespace)
+                setattr(cls, method, namespace[method])
+            setattr(model, class_name, cls)
+        return model, supported, self._load_runtime()
+
+    def final_inputs(self, runtime, banks=1, enabled=True):
+        final = helpers._FakeFinalLayer()
+        setattr(final, runtime._FINAL_ENABLE_FLAG, enabled)
+        for head in (final.video_out, final.audio_out):
+            head.out_features = 4
+            head.weight.shape = (banks * 4, 16)
+        trace = []
+        return final, helpers._TraceTensor("x", "float16", trace), helpers._TraceTensor("t", "float16", trace), trace
+
+    def test_v0345_real_source_installs_and_legacy_final_runs_fp32(self):
+        _, _, runtime = self.load_upstream("model_v0345.py")
+        self.assertTrue(runtime.PATCH_STATUS["installed"], runtime.PATCH_STATUS)
+        final, x, t, trace = self.final_inputs(runtime)
+        video, audio = runtime._patched_final_forward(final, x, t, (0, 4, 0), (4, 8, 1))
+        self.assertEqual((video.dtype, audio.dtype), ("float32", "float32"))
+        self.assertIn(("norm", "float32"), trace)
+        self.assertIn(("t.to", "float32"), trace)
+        self.assertIn(("video_out", "float32"), trace)
+        self.assertIn(("audio_out", "float32"), trace)
+
+    def test_pdd_real_source_installs_and_eight_positional_arguments_work(self):
+        _, _, runtime = self.load_upstream("model_pdd.py")
+        self.assertTrue(runtime.PATCH_STATUS["installed"], runtime.PATCH_STATUS)
+        final, x, t, _ = self.final_inputs(runtime)
+        video, audio = runtime._patched_final_forward(final, x, t, (0, 4, 0), (4, 8, 1), 1.0, None, (12.0, 3.0))
+        self.assertEqual((video.dtype, audio.dtype), ("float32", "float32"))
+
+    def test_pdd_bank_schedule_and_distinct_stream_shifts_are_preserved(self):
+        _, _, runtime = self.load_upstream("model_pdd.py")
+        final, x, t, trace = self.final_inputs(runtime, banks=4)
+        # Video base-grid interval .0 -> .5 spans heads 0 and 1.
+        schedule = _Schedule([1.0, 12.0 / 13.0, 0.0])
+        runtime._patched_final_forward(final, x, t, (0, 4, 0), (4, 8, 1),
+                                       sigma=1.0, sample_sigmas=schedule, shifts=(12.0, 3.0))
+        self.assertEqual(self.pdd_calls, [("video_out", "float32", 4, 0, 2, 12.0),
+                                         ("audio_out", "float32", 4, 0, 2, 3.0)])
+        self.assertIn(("norm", "float32"), trace)
+
+    def test_missing_pdd_schedule_still_raises_upstream_error(self):
+        _, _, runtime = self.load_upstream("model_pdd.py")
+        final, x, t, _ = self.final_inputs(runtime, banks=4)
+        with self.assertRaisesRegex(ValueError, "sigma schedule"):
+            runtime._patched_final_forward(final, x, t, (0, 4, 0), (4, 8, 1), 1.0, None, (12.0, 3.0))
+
+    def test_inactive_cpu_and_training_paths_forward_arguments_without_casting(self):
+        self._install_fake_modules()
+        runtime = self._load_runtime()
+        calls = []
+        runtime._ORIGINAL_FINAL_FORWARD = lambda *args, **kwargs: calls.append((args, kwargs))
+        for mode in ("inactive", "cpu", "training"):
+            final, x, t, trace = self.final_inputs(runtime, enabled=mode != "inactive")
+            if mode == "cpu":
+                x.device.type = "cpu"
+            runtime.model_management.in_training = mode == "training"
+            schedule = object()
+            runtime._patched_final_forward(final, x, t, (0, 4, 0), (4, 8, 1), 0.5,
+                                           sample_sigmas=schedule, shifts=(12.0, 3.0))
+            self.assertIs(calls[-1][0][1], x)
+            self.assertIs(calls[-1][0][2], t)
+            self.assertEqual(calls[-1][0][-1], 0.5)
+            self.assertIs(calls[-1][1]["sample_sigmas"], schedule)
+            self.assertEqual(trace, [])
+
+    def test_final_forwards_future_keyword_and_segment_identity(self):
+        self._install_fake_modules()
+        runtime = self._load_runtime()
+        runtime._ORIGINAL_FINAL_FORWARD = lambda *args, **kwargs: (args, kwargs)
+        final, x, t, _ = self.final_inputs(runtime)
+        video_seg, audio_seg, extension = object(), object(), object()
+        args, kwargs = runtime._patched_final_forward(final, x, t, video_seg, audio_seg, extension=extension)
+        self.assertIs(args[3], video_seg)
+        self.assertIs(args[4], audio_seg)
+        self.assertIs(kwargs["extension"], extension)
+        self.assertEqual((args[1].dtype, args[2].dtype), ("float32", "float32"))
+
+    def test_new_block_attention_override_receives_fp16_branch(self):
+        self._install_fake_modules()
+        runtime = self._load_runtime()
+        block = helpers._FakeBlock()
+        setattr(block, runtime._BLOCK_ENABLE_FLAG, True)
+        block.mlp = lambda value: value
+        calls = []
+
+        def override(value, **kwargs):
+            calls.append((value.dtype, kwargs))
+            return value
+
+        result = runtime._patched_block_forward(block, helpers._TraceTensor("x", "float16"),
+            helpers._TraceTensor("t", "float16"), [(0, 8, 0)], "rope", {"test": True}, override)
+        self.assertEqual(result.dtype, "float32")
+        self.assertEqual(calls, [("float16", {"rope_freqs": "rope", "transformer_options": {"test": True}})])
+
+    def test_inactive_new_block_delegates_attention_keyword(self):
+        _, _, runtime = self.load_upstream("model_pdd.py")
+        calls = []
+        runtime._ORIGINAL_BLOCK_FORWARD = lambda *args, **kwargs: calls.append(kwargs)
+        override = object()
+        runtime._patched_block_forward(helpers._FakeBlock(), helpers._TraceTensor("x", "float16"),
+                                       None, None, None, attention=override)
+        self.assertIs(calls[0]["attention"], override)
+
+    def test_unknown_block_parameter_disables_before_dtype_registration(self):
+        model, supported = self._install_fake_modules()
+
+        def future_block(self, x, t_emb, mod_segments, rope_freqs, transformer_options={}, new_feature=None):
+            return x
+
+        future_block.__module__ = model.__name__
+        model.DiTBlock.forward = future_block
+        runtime = self._load_runtime()
+        self.assertFalse(runtime.PATCH_STATUS["installed"])
+        self.assertIn("unknown parameters", runtime.PATCH_STATUS["reason"])
+        self.assertEqual(supported.MiniMaxH3.supported_inference_dtypes, ["bfloat16", "float32"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/build_release.py
+++ b/tools/build_release.py
@@ -1,0 +1,83 @@
+"""Build and verify the standalone v0.1.4 server-test ZIP (standard library)."""
+
+import ast
+import hashlib
+import json
+from pathlib import Path
+import re
+import subprocess
+import sys
+import zipfile
+
+
+ROOT = Path(__file__).resolve().parents[1]
+VERSION = "0.1.4"
+FOLDER = "minimax-h3-v100-l3-clean"
+FILES = (
+    "__init__.py", "runtime_patch.py", "README.md", "README_zh-CN.md",
+    "NOTICE.md", "LICENSE", "tests/test_runtime_patch.py", "tests/test_upstream_compat.py",
+    "tests/fixtures/model_v0345.py", "tests/fixtures/model_pdd.py",
+    "tests/fixtures/PROVENANCE.json", "tools/build_release.py",
+)
+
+
+def digest(data):
+    return hashlib.sha256(data).hexdigest()
+
+
+def main():
+    payload = {name: (ROOT / name).read_bytes() for name in FILES}
+    for name, data in payload.items():
+        if name.endswith(".py"):
+            ast.parse(data.decode("utf-8-sig"), filename=name)
+    provenance = json.loads(payload["tests/fixtures/PROVENANCE.json"])
+    for name, info in provenance["files"].items():
+        assert digest(payload["tests/fixtures/" + name]) == info["sha256"], name
+    for name in ("__init__.py", "runtime_patch.py"):
+        assert f'"{VERSION}"' in payload[name].decode("utf-8"), name
+
+    run = subprocess.run([sys.executable, "-B", "-m", "unittest", "discover", "-s", "tests", "-v"],
+                         cwd=ROOT, capture_output=True, text=True, encoding="utf-8")
+    if run.returncode:
+        print(run.stdout + run.stderr)
+        raise SystemExit(run.returncode)
+    count = int(re.search(r"Ran (\d+) tests", run.stderr).group(1))
+    manifest = {
+        "package": "minimax-h3-v100-patch", "version": VERSION,
+        "profile_id": "minimax-h3-v100-v014-native-fp16-branches",
+        "install_folder": FOLDER, "generated_date": "2026-09-06",
+        "compatibility": "ComfyUI v0.34.5 and PDD source fixtures; see tests/fixtures/PROVENANCE.json",
+        "runtime_status": "V100 server inference, quality, speed and memory tests pending",
+        "validation": {"python_ast": "passed", "dependency_free_tests": count,
+                       "upstream_final_argument_and_dtype_flow": "passed",
+                       "real_torch_numerical_tests": "not run", "gpu_inference": "not run"},
+        "files": {name: {"bytes": len(data), "sha256": digest(data)} for name, data in payload.items()},
+    }
+    manifest_bytes = (json.dumps(manifest, indent=2) + "\n").encode("utf-8")
+    (ROOT / "MANIFEST.json").write_bytes(manifest_bytes)
+    payload["MANIFEST.json"] = manifest_bytes
+    archive_path = ROOT.parent / f"minimax-h3-v100-v{VERSION}.zip"
+    with zipfile.ZipFile(archive_path, "w", compression=zipfile.ZIP_DEFLATED, compresslevel=9) as archive:
+        for name, data in sorted(payload.items()):
+            entry = zipfile.ZipInfo(f"{FOLDER}/{name}", date_time=(2026, 9, 6, 0, 0, 0))
+            entry.compress_type = zipfile.ZIP_DEFLATED
+            archive.writestr(entry, data)
+    with zipfile.ZipFile(archive_path) as archive:
+        assert archive.testzip() is None
+        assert set(archive.namelist()) == {f"{FOLDER}/{name}" for name in payload}
+        for name, data in payload.items():
+            assert archive.read(f"{FOLDER}/{name}") == data, name
+    archive_hash = digest(archive_path.read_bytes())
+    archive_path.with_suffix(".zip.sha256").write_text(
+        f"{archive_hash}  {archive_path.name}\n", encoding="utf-8")
+    report = f"{count} tests passed; Python AST and upstream source hashes passed; {len(payload)} ZIP entries verified.\n"
+    (ROOT.parent / "v0.1.4-validation.txt").write_text(
+        report + run.stderr + f"\nZIP SHA256: {archive_hash}\nGPU inference: not run; server test pending.\n",
+        encoding="utf-8")
+    print(report.strip())
+    print(archive_path)
+    print(archive_hash)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
ComfyUI's updated MiniMax H3 path passes `sigma`, `sample_sigmas`, and `shifts` to `FinalLayer`, which caused v0.1.3 to fail with `_patched_final_forward() takes 5 positional arguments but 8 were given`.

v0.1.4 preserves every upstream FinalLayer argument and delegates the original modulation/PDD head logic after applying the FP32 safety casts. It also supports the optional DiT block `attention` override and fails closed on unknown signatures. The release ZIP excludes TE adapters, TE-Speed, and the legacy source patcher.

Validation: 23 dependency-free tests pass against pinned ComfyUI v0.34.5 and PDD source fixtures; package manifest, ZIP contents, and SHA-256 were verified. Real V100 inference, video/audio quality, speed, and memory remain pending server testing.
